### PR TITLE
Fix vendor

### DIFF
--- a/go-build-repo-mod.sh
+++ b/go-build-repo-mod.sh
@@ -15,7 +15,7 @@ done
 errCode=0
 # Assume parent folder of go.mod is module root folder
 #
-for sub in $(find . -name go.mod | xargs -n1 dirname | sort -u) ; do
+for sub in $(find . -name go.mod -not -path './vendor/*' | xargs -n1 dirname | sort -u) ; do
 	pushd "${sub}" >/dev/null
 	"${cmd[@]}" "${OPTIONS[@]}" ./...
 	if [ $? -ne 0 ]; then

--- a/go-test-repo-mod.sh
+++ b/go-test-repo-mod.sh
@@ -15,7 +15,7 @@ done
 errCode=0
 # Assume parent folder of go.mod is module root folder
 #
-for sub in $(find . -name go.mod | xargs -n1 dirname | sort -u) ; do
+for sub in $(find . -name go.mod -not -path './vendor/*' | xargs -n1 dirname | sort -u) ; do
 	pushd "${sub}" >/dev/null
 	"${cmd[@]}" "${OPTIONS[@]}" ./...
 	if [ $? -ne 0 ]; then

--- a/go-vet-repo-mod.sh
+++ b/go-vet-repo-mod.sh
@@ -15,7 +15,7 @@ done
 errCode=0
 # Assume parent folder of go.mod is module root folder
 #
-for sub in $(find . -name go.mod | xargs -n1 dirname | sort -u) ; do
+for sub in $(find . -name go.mod -not -path './vendor/*' | xargs -n1 dirname | sort -u) ; do
 	pushd "${sub}" >/dev/null
 	"${cmd[@]}" "${OPTIONS[@]}" ./...
 	if [ $? -ne 0 ]; then

--- a/golangci-lint-repo-mod.sh
+++ b/golangci-lint-repo-mod.sh
@@ -15,7 +15,7 @@ done
 errCode=0
 # Assume parent folder of go.mod is module root folder
 #
-for sub in $(find . -name go.mod | xargs -n1 dirname | sort -u) ; do
+for sub in $(find . -name go.mod -not -path './vendor/*' | xargs -n1 dirname | sort -u) ; do
 	pushd "${sub}" >/dev/null
 	"${cmd[@]}" "${OPTIONS[@]}" ./...
 	if [ $? -ne 0 ]; then


### PR DESCRIPTION
fixes #4 

This fix includes only the most common case for when modules are vendor-ed.

Why would I vendor modules in mod mode? - for development convenience and debugging.