### PR TITLE
Use temporary directories for go-build* output

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -302,6 +302,21 @@
   pass_filenames: true
 
 # ==============================================================================
+# go gofumpt
+#   * File-based
+#   * Executes if any .go files modified
+# ==============================================================================
+- id: go-gofumpt
+  name: "go-gofumpt"
+  entry: go-gofumpt.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'gofumpt [$ARGS] $FILE' for each staged .go file"
+  pass_filenames: true
+
+
+# ==============================================================================
 # golangci-lint-mod
 #   * Folder-Based
 #   * Recursive

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,15 +6,15 @@
 #   * Executes if any .go files modified
 #   * Executes if go.mod modified
 # ==============================================================================
--   id: go-build-mod
-    name: 'go-build-mod'
-    entry: go-build-mod.sh
-    files: '(\.go$)|(\bgo\.mod$)'
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'cd $(mod_root $FILE); go build -o /dev/null [$ARGS] ./...' for each staged .go file"
-    pass_filenames: true
-    require_serial: true
+- id: go-build-mod
+  name: "go-build-mod"
+  entry: go-build-mod.sh
+  files: '(\.go$)|(\bgo\.mod$)'
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'cd $(mod_root $FILE); go build -o /dev/null [$ARGS] ./...' for each staged .go file"
+  pass_filenames: true
+  require_serial: true
 
 # ==============================================================================
 # go-build-pkg
@@ -22,15 +22,15 @@
 #   * Targets folder containing staged file
 #   * Executes if any .go files modified
 # ==============================================================================
--   id: go-build-pkg
-    name: 'go-build-pkg'
-    entry: go-build-pkg.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'go build -o /dev/null [$ARGS] ./$(dirname $FILE)' for each staged .go file"
-    pass_filenames: true
-    require_serial: true
+- id: go-build-pkg
+  name: "go-build-pkg"
+  entry: go-build-pkg.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'go build -o /dev/null [$ARGS] ./$(dirname $FILE)' for each staged .go file"
+  pass_filenames: true
+  require_serial: true
 
 # ==============================================================================
 # go-build-repo-mod
@@ -40,14 +40,14 @@
 #   * Executes if any .go files modified
 #   * Executes if go.mod modified
 # ==============================================================================
--   id: go-build-repo-mod
-    name: 'go-build-repo-mod'
-    entry: go-build-repo-mod.sh
-    files: '(\.go$)|(\bgo\.mod$)'
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'cd $(mod_root); go build -o $(tempfile) [$ARGS] ./...' for each module in the repo"
-    pass_filenames: false
+- id: go-build-repo-mod
+  name: "go-build-repo-mod"
+  entry: go-build-repo-mod.sh
+  files: '(\.go$)|(\bgo\.mod$)'
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'cd $(mod_root); go build -o $(tempfile) [$ARGS] ./...' for each module in the repo"
+  pass_filenames: false
 
 # ==============================================================================
 # go-build-repo-pkg
@@ -55,28 +55,28 @@
 #   * Recursive
 #   * Executes if any .go files modified
 # ==============================================================================
--   id: go-build-repo-pkg
-    name: 'go-build-repo-pkg'
-    entry: go-build-repo-pkg.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'go build -o /dev/null [$ARGS] ./...' in repo root folder"
-    pass_filenames: false
+- id: go-build-repo-pkg
+  name: "go-build-repo-pkg"
+  entry: go-build-repo-pkg.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'go build -o /dev/null [$ARGS] ./...' in repo root folder"
+  pass_filenames: false
 
 # ==============================================================================
 # go-critic
 #   * File-based
 #   * Executes if any .go files modified
 # ==============================================================================
--   id: go-critic
-    name: 'go-critic'
-    entry: go-critic.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'gocritic check [$ARGS] $FILE' for each staged .go file"
-    pass_filenames: true
+- id: go-critic
+  name: "go-critic"
+  entry: go-critic.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'gocritic check [$ARGS] $FILE' for each staged .go file"
+  pass_filenames: true
 
 # ==============================================================================
 # go-fmt
@@ -85,14 +85,14 @@
 # NOTES:
 #   `go fmt` delegates to `gofmt`, so we'll invote `gofmt` directly.
 # ==============================================================================
--   id: go-fmt
-    name: 'go-fmt'
-    entry: go-fmt.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'gofmt -l -d [$ARGS] $FILE' for each staged .go file"
-    pass_filenames: true
+- id: go-fmt
+  name: "go-fmt"
+  entry: go-fmt.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'gofmt -l -d [$ARGS] $FILE' for each staged .go file"
+  pass_filenames: true
 
 # ==============================================================================
 # go-imports
@@ -101,28 +101,28 @@
 # NOTES:
 #   Replaces go-fmt-fix
 # ==============================================================================
--   id: go-imports
-    name: 'go-imports'
-    entry: go-imports.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'goimports -l -d [$ARGS] $FILE' for each staged .go file"
-    pass_filenames: true
+- id: go-imports
+  name: "go-imports"
+  entry: go-imports.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'goimports -l -d [$ARGS] $FILE' for each staged .go file"
+  pass_filenames: true
 
 # ==============================================================================
 # go-lint
 #   * File-based
 #   * Executes if any .go files modified
 # ==============================================================================
--   id: go-lint
-    name: 'go-lint'
-    entry: go-lint.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'golint -set_exit_status [$ARGS] $FILE' for each staged .go file"
-    pass_filenames: true
+- id: go-lint
+  name: "go-lint"
+  entry: go-lint.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'golint -set_exit_status [$ARGS] $FILE' for each staged .go file"
+  pass_filenames: true
 
 # ==============================================================================
 # go-returns
@@ -131,14 +131,14 @@
 # NOTES:
 #   Replaces go-imports-fix & go-fmt-fix
 # ==============================================================================
--   id: go-returns
-    name: 'go-returns'
-    entry: go-returns.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'goreturns -l -d [$ARGS] $FILE' for each staged .go file"
-    pass_filenames: true
+- id: go-returns
+  name: "go-returns"
+  entry: go-returns.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'goreturns -l -d [$ARGS] $FILE' for each staged .go file"
+  pass_filenames: true
 
 # ==============================================================================
 # go-test-mod
@@ -148,15 +148,15 @@
 #   * Executes if any .go files modified
 #   * Executes if go.mod modified
 # ==============================================================================
--   id: go-test-mod
-    name: 'go-test-mod'
-    entry: go-test-mod.sh
-    files: '(\.go$)|(\bgo\.mod$)'
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'cd $(mod_root $FILE); go test [$ARGS] ./...' for each staged .go file"
-    pass_filenames: true
-    require_serial: true
+- id: go-test-mod
+  name: "go-test-mod"
+  entry: go-test-mod.sh
+  files: '(\.go$)|(\bgo\.mod$)'
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'cd $(mod_root $FILE); go test [$ARGS] ./...' for each staged .go file"
+  pass_filenames: true
+  require_serial: true
 
 # ==============================================================================
 # go-test-pkg
@@ -164,15 +164,15 @@
 #   * Targets folder containing staged file
 #   * Executes if any .go files modified
 # ==============================================================================
--   id: go-test-pkg
-    name: 'go-test-pkg'
-    entry: go-test-pkg.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'go test [$ARGS] ./$(dirname $FILE)' for each staged .go file"
-    pass_filenames: true
-    require_serial: true
+- id: go-test-pkg
+  name: "go-test-pkg"
+  entry: go-test-pkg.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'go test [$ARGS] ./$(dirname $FILE)' for each staged .go file"
+  pass_filenames: true
+  require_serial: true
 
 # ==============================================================================
 # go-test-repo-mod
@@ -182,14 +182,14 @@
 #   * Executes if any .go files modified
 #   * Executes if go.mod modified
 # ==============================================================================
--   id: go-test-repo-mod
-    name: 'go-test-repo-mod'
-    entry: go-test-repo-mod.sh
-    files: '(\.go$)|(\bgo\.mod$)'
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'cd $(mod_root); go test [$ARGS] ./...' for each module in the repo"
-    pass_filenames: false
+- id: go-test-repo-mod
+  name: "go-test-repo-mod"
+  entry: go-test-repo-mod.sh
+  files: '(\.go$)|(\bgo\.mod$)'
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'cd $(mod_root); go test [$ARGS] ./...' for each module in the repo"
+  pass_filenames: false
 
 # ==============================================================================
 # go-test-repo-pkg
@@ -197,14 +197,14 @@
 #   * Recursive
 #   * Executes if any .go files modified
 # ==============================================================================
--   id: go-test-repo-pkg
-    name: 'go-test-repo-pkg'
-    entry: go-test-repo-pkg.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'go test [$ARGS] ./...' in repo root folder"
-    pass_filenames: false
+- id: go-test-repo-pkg
+  name: "go-test-repo-pkg"
+  entry: go-test-repo-pkg.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'go test [$ARGS] ./...' in repo root folder"
+  pass_filenames: false
 
 # ==============================================================================
 # go-vet-mod
@@ -214,15 +214,15 @@
 #   * Executes if any .go files modified
 #   * Executes if go.mod modified
 # ==============================================================================
--   id: go-vet-mod
-    name: 'go-vet-mod'
-    entry: go-vet-mod.sh
-    files: '(\.go$)|(\bgo\.mod$)'
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'cd $(mod_root $FILE); go vet [$ARGS] ./...' for each staged .go file"
-    pass_filenames: true
-    require_serial: true
+- id: go-vet-mod
+  name: "go-vet-mod"
+  entry: go-vet-mod.sh
+  files: '(\.go$)|(\bgo\.mod$)'
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'cd $(mod_root $FILE); go vet [$ARGS] ./...' for each staged .go file"
+  pass_filenames: true
+  require_serial: true
 
 # ==============================================================================
 # go-vet-pkg
@@ -230,15 +230,15 @@
 #   * Targets folder containing staged file
 #   * Executes if any .go files modified
 # ==============================================================================
--   id: go-vet-pkg
-    name: 'go-vet-pkg'
-    entry: go-vet-pkg.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'go vet [$ARGS] ./$(dirname $FILE)' for each staged .go file"
-    pass_filenames: true
-    require_serial: true
+- id: go-vet-pkg
+  name: "go-vet-pkg"
+  entry: go-vet-pkg.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'go vet [$ARGS] ./$(dirname $FILE)' for each staged .go file"
+  pass_filenames: true
+  require_serial: true
 
 # ==============================================================================
 # go-vet-repo-mod
@@ -248,14 +248,14 @@
 #   * Executes if any .go files modified
 #   * Executes if go.mod modified
 # ==============================================================================
--   id: go-vet-repo-mod
-    name: 'go-vet-repo-mod'
-    entry: go-vet-repo-mod.sh
-    files: '(\.go$)|(\bgo\.mod$)'
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'cd $(mod_root); go vet [$ARGS] ./...' for each module in the repo"
-    pass_filenames: false
+- id: go-vet-repo-mod
+  name: "go-vet-repo-mod"
+  entry: go-vet-repo-mod.sh
+  files: '(\.go$)|(\bgo\.mod$)'
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'cd $(mod_root); go vet [$ARGS] ./...' for each module in the repo"
+  pass_filenames: false
 
 # ==============================================================================
 # go-vet-repo-pkg
@@ -263,14 +263,14 @@
 #   * Recursive
 #   * Executes if any .go files modified
 # ==============================================================================
--   id: go-vet-repo-pkg
-    name: 'go-vet-repo-pkg'
-    entry: go-vet-repo-pkg.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'go vet [$ARGS] ./...' in repo root folder"
-    pass_filenames: false
+- id: go-vet-repo-pkg
+  name: "go-vet-repo-pkg"
+  entry: go-vet-repo-pkg.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'go vet [$ARGS] ./...' in repo root folder"
+  pass_filenames: false
 
 # ==============================================================================
 # go-vet
@@ -279,14 +279,27 @@
 # NOTES:
 #   `go vet` appears to work on single files when given them as args.
 # ==============================================================================
--   id: go-vet
-    name: 'go-vet'
-    entry: go-vet.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'go vet [$ARGS] $FILE' for each staged .go file"
-    pass_filenames: true
+- id: go-vet
+  name: "go-vet"
+  entry: go-vet.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'go vet [$ARGS] $FILE' for each staged .go file"
+  pass_filenames: true
+
+# ==============================================================================
+# go gci
+#   * File-based
+#   * Executes if any .go files modified
+- id: go-gci
+  name: "go-gci"
+  entry: go-gci.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "RUn 'gci [$ARGS] $FILE' for each staged .go file"
+  pass_filenames: true
 
 # ==============================================================================
 # golangci-lint-mod
@@ -296,15 +309,15 @@
 #   * Executes if any .go files modified
 #   * Executes if go.mod modified
 # ==============================================================================
--   id: golangci-lint-mod
-    name: 'golangci-lint-mod'
-    entry: golangci-lint-mod.sh
-    files: '(\.go$)|(\bgo\.mod$)'
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'cd $(mod_root $FILE); golangci-lint run [$ARGS] ./...' for each staged .go file"
-    pass_filenames: true
-    require_serial: true
+- id: golangci-lint-mod
+  name: "golangci-lint-mod"
+  entry: golangci-lint-mod.sh
+  files: '(\.go$)|(\bgo\.mod$)'
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'cd $(mod_root $FILE); golangci-lint run [$ARGS] ./...' for each staged .go file"
+  pass_filenames: true
+  require_serial: true
 
 # ==============================================================================
 # golangci-lint-pkg
@@ -312,15 +325,15 @@
 #   * Targets folder containing staged file
 #   * Executes if any .go files modified
 # ==============================================================================
--   id: golangci-lint-pkg
-    name: 'golangci-lint-pkg'
-    entry: golangci-lint-pkg.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'golangci-lint run [$ARGS] ./$(dirname $FILE)' for each staged .go file"
-    pass_filenames: true
-    require_serial: true
+- id: golangci-lint-pkg
+  name: "golangci-lint-pkg"
+  entry: golangci-lint-pkg.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'golangci-lint run [$ARGS] ./$(dirname $FILE)' for each staged .go file"
+  pass_filenames: true
+  require_serial: true
 
 # ==============================================================================
 # golangci-lint-repo-mod
@@ -330,14 +343,14 @@
 #   * Executes if any .go files modified
 #   * Executes if go.mod modified
 # ==============================================================================
--   id: golangci-lint-repo-mod
-    name: 'golangci-lint-repo-mod'
-    entry: golangci-lint-repo-mod.sh
-    files: '(\.go$)|(\bgo\.mod$)'
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'cd $(mod_root); golangci-lint run [$ARGS] ./...' for each module in the repo"
-    pass_filenames: false
+- id: golangci-lint-repo-mod
+  name: "golangci-lint-repo-mod"
+  entry: golangci-lint-repo-mod.sh
+  files: '(\.go$)|(\bgo\.mod$)'
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'cd $(mod_root); golangci-lint run [$ARGS] ./...' for each module in the repo"
+  pass_filenames: false
 
 # ==============================================================================
 # golangci-lint-repo-pkg
@@ -345,14 +358,14 @@
 #   * Recursive
 #   * Executes if any .go files modified
 # ==============================================================================
--   id: golangci-lint-repo-pkg
-    name: 'golangci-lint-repo-pkg'
-    entry: golangci-lint-repo-pkg.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'golangci-lint run [$ARGS] ./...' in repo root folder"
-    pass_filenames: false
+- id: golangci-lint-repo-pkg
+  name: "golangci-lint-repo-pkg"
+  entry: golangci-lint-repo-pkg.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'golangci-lint run [$ARGS] ./...' in repo root folder"
+  pass_filenames: false
 
 # ==============================================================================
 # golangci-lint
@@ -361,11 +374,11 @@
 # NOTES:
 #   `golangci-lint` appears to work on single files when given them as args.
 # ==============================================================================
--   id: golangci-lint
-    name: 'golangci-lint'
-    entry: golangci-lint.sh
-    types: [go]
-    exclude: '(^|/)vendor/'
-    language: 'script'
-    description: "Run 'golangci-lint run [$ARGS] $FILE' for each staged .go file"
-    pass_filenames: true
+- id: golangci-lint
+  name: "golangci-lint"
+  entry: golangci-lint.sh
+  types: [go]
+  exclude: "(^|/)vendor/"
+  language: "script"
+  description: "Run 'golangci-lint run [$ARGS] $FILE' for each staged .go file"
+  pass_filenames: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -83,7 +83,7 @@
 #   * File-based
 #   * Executes if any .go files modified
 # NOTES:
-#   `go fmt` delegates to `gofmt`, so we'll invote `gofmt` directly.
+#   `go fmt` delegates to `gofmt`, so we'll invoke `gofmt` directly.
 # ==============================================================================
 - id: go-fmt
   name: "go-fmt"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -46,7 +46,7 @@
     files: '(\.go$)|(\bgo\.mod$)'
     exclude: '(^|/)vendor/'
     language: 'script'
-    description: "Run 'cd $(mod_root); go build -o /dev/null [$ARGS] ./...' for each module in the repo"
+    description: "Run 'cd $(mod_root); go build -o $(tempfile) [$ARGS] ./...' for each module in the repo"
     pass_filenames: false
 
 # ==============================================================================

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -298,7 +298,7 @@
   types: [go]
   exclude: "(^|/)vendor/"
   language: "script"
-  description: "RUn 'gci [$ARGS] $FILE' for each staged .go file"
+  description: "Run 'gci [$ARGS] $FILE' for each staged .go file"
   pass_filenames: true
 
 # ==============================================================================

--- a/go-build-mod.sh
+++ b/go-build-mod.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
+tmpfile=$(mktemp /tmp/go-build.XXXXXX)
+outfile=$(mktemp /tmp/go-build.out.XXXXXX)
 
-cmd=(go build -o /dev/null)
+
+cmd=(go build -o ${tmpfile})
 
 export GO111MODULE=on
 
@@ -60,11 +63,11 @@ done
 
 errCode=0
 for sub in $(find_module_roots "${FILES[@]}" | sort -u) ; do
-	pushd "${sub}" >/dev/null
+	pushd "${sub}" > outfile
 	"${cmd[@]}" "${OPTIONS[@]}" ./...
 	if [ $? -ne 0 ]; then
 		errCode=1
 	fi
-	popd >/dev/null
+	popd > outfile
 done
 exit $errCode

--- a/go-build-mod.sh
+++ b/go-build-mod.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-tmpfile=$(mktemp /tmp/go-build.XXXXXX)
-mkdir ${tmpfile}
+tmpfile=$(mktemp -d /tmp/go-build.XXXXXX)
 outfile=$(mktemp /tmp/go-build.out.XXXXXX)
 
 

--- a/go-build-mod.sh
+++ b/go-build-mod.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 tmpfile=$(mktemp /tmp/go-build.XXXXXX)
+mkdir ${tmpfile}
 outfile=$(mktemp /tmp/go-build.out.XXXXXX)
 
 

--- a/go-build-pkg.sh
+++ b/go-build-pkg.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-cmd=(go build -o /dev/null)
+tmpfile=$(mktemp /tmp/go-build.XXXXXX)
+cmd=(go build -o ${tmpfile})
 
 export GO111MODULE=off
 

--- a/go-build-pkg.sh
+++ b/go-build-pkg.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-tmpfile=$(mktemp /tmp/go-build.XXXXXX)
-mkdir ${tmpfile}
+tmpfile=$(mktemp -d /tmp/go-build.XXXXXX)
 cmd=(go build -o ${tmpfile})
 
 export GO111MODULE=off

--- a/go-build-pkg.sh
+++ b/go-build-pkg.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 tmpfile=$(mktemp /tmp/go-build.XXXXXX)
+mkdir ${tmpfile}
 cmd=(go build -o ${tmpfile})
 
 export GO111MODULE=off

--- a/go-build-repo-mod.sh
+++ b/go-build-repo-mod.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-cmd=(go build -o /dev/null)
+tmpfile=$(mktemp /tmp/go-build.XXXXXX)
+outfile=$(mktemp /tmp/go-build.out.XXXXXX)
+cmd=(go build -o ${tmpfile})
 
 export GO111MODULE=on
 
@@ -16,11 +18,11 @@ errCode=0
 # Assume parent folder of go.mod is module root folder
 #
 for sub in $(find . -name go.mod -not -path '*/vendor/*' | xargs -n1 dirname | sort -u) ; do
-	pushd "${sub}" >/dev/null
+	pushd "${sub}" > ${outfile}
 	"${cmd[@]}" "${OPTIONS[@]}" ./...
 	if [ $? -ne 0 ]; then
 		errCode=1
 	fi
-	popd >/dev/null
+	popd > ${outfile}
 done
 exit $errCode

--- a/go-build-repo-mod.sh
+++ b/go-build-repo-mod.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-tmpfile=$(mktemp /tmp/go-build.XXXXXX)
-mkdir ${tmpfile}
+tmpfile=$(mktemp -d /tmp/go-build.XXXXXX)
 outfile=$(mktemp /tmp/go-build.out.XXXXXX)
 cmd=(go build -o ${tmpfile})
 

--- a/go-build-repo-mod.sh
+++ b/go-build-repo-mod.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 tmpfile=$(mktemp /tmp/go-build.XXXXXX)
+mkdir ${tmpfile}
 outfile=$(mktemp /tmp/go-build.out.XXXXXX)
 cmd=(go build -o ${tmpfile})
 

--- a/go-build-repo-pkg.sh
+++ b/go-build-repo-pkg.sh
@@ -2,6 +2,7 @@
 set -e
 
 tmpfile=$(mktemp /tmp/go-build.XXXXXX)
+mkdir ${tmpfile}
 cmd=(go build -o ${tmpfile})
 
 export GO111MODULE=off

--- a/go-build-repo-pkg.sh
+++ b/go-build-repo-pkg.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-tmpfile=$(mktemp /tmp/go-build.XXXXXX)
-mkdir ${tmpfile}
+tmpfile=$(mktemp -d /tmp/go-build.XXXXXX)
 cmd=(go build -o ${tmpfile})
 
 export GO111MODULE=off

--- a/go-build-repo-pkg.sh
+++ b/go-build-repo-pkg.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-cmd=(go build -o /dev/null)
+tmpfile=$(mktemp /tmp/go-build.XXXXXX)
+cmd=(go build -o ${tmpfile})
 
 export GO111MODULE=off
 

--- a/go-fmt.sh
+++ b/go-fmt.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cmd=(gofmt -l -d)
+cmd=(gofmt -l -w)
 
 OPTIONS=()
 # If arg doesn't pass [ -f ] check, then it is assumed to be an option

--- a/go-gci.sh
+++ b/go-gci.sh
@@ -39,6 +39,7 @@ done
 
 errCode=0
 for file in "${FILES[@]}"; do
+	echo "${cmd[@]} ${OPTIONS[@]} ${file}"
 	output=$("${cmd[@]}" "${OPTIONS[@]}" "${file}" 2>&1)
 	if [ ! -z "${output}" ]; then
 		echo -n "${output}"

--- a/go-gci.sh
+++ b/go-gci.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+cmd=(gci)
+
+OPTIONS=()
+# If arg doesn't pass [ -f ] check, then it is assumed to be an option
+#
+while [ $# -gt 0 ] && [ "$1" != "-" ] && [ "$1" != "--" ] && [ ! -f "$1" ]; do
+	OPTIONS+=("$1")
+	shift
+done
+
+FILES=()
+# Assume start of file list (may still be options)
+#
+while [ $# -gt 0 ] && [ "$1" != "-" ] && [ "$1" != "--" ]; do
+	FILES+=("$1")
+	shift
+done
+
+# If '--' next, then files = options
+#
+if [ $# -gt 0 ]; then
+	if [ "$1" == "-" ] || [ "$1" == "--" ]; then
+		shift
+		# Append to previous options
+		#
+		OPTIONS=("${OPTIONS[@]}" "${FILES[@]}")
+		FILES=()
+	fi
+fi
+
+# Any remaining arguments are assumed to be files
+#
+while [ $# -gt 0 ]; do
+	FILES+=("$1")
+	shift
+done
+
+errCode=0
+for file in "${FILES[@]}"; do
+	output=$("${cmd[@]}" "${OPTIONS[@]}" "${file}" 2>&1)
+	if [ ! -z "${output}" ]; then
+		echo -n "${output}"
+		echo "" # newline
+		errCode=1
+	fi
+done
+exit $errCode

--- a/go-gci.sh
+++ b/go-gci.sh
@@ -39,8 +39,6 @@ done
 
 errCode=0
 for file in "${FILES[@]}"; do
-	echo $file
-	echo "${cmd[@]} ${OPTIONS[@]} ${file}"
 	output=$("${cmd[@]}" "${OPTIONS[@]}" "${file}" 2>&1)
 	if [ ! -z "${output}" ]; then
 		echo -n "${output}"

--- a/go-gci.sh
+++ b/go-gci.sh
@@ -39,6 +39,7 @@ done
 
 errCode=0
 for file in "${FILES[@]}"; do
+	echo $file
 	echo "${cmd[@]} ${OPTIONS[@]} ${file}"
 	output=$("${cmd[@]}" "${OPTIONS[@]}" "${file}" 2>&1)
 	if [ ! -z "${output}" ]; then

--- a/go-gofumpt.sh
+++ b/go-gofumpt.sh
@@ -39,10 +39,8 @@ done
 
 errCode=0
 for file in "${FILES[@]}"; do
-	output=$("${cmd[@]}" "${OPTIONS[@]}" "${file}" 2>&1)
-	if [ ! -z "${output}" ]; then
-		echo -n "${output}"
-		echo "" # newline
+	$("${cmd[@]}" "${OPTIONS[@]}" "${file}" 2>&1)
+	if [ $? -ne 0 ]; then
 		errCode=1
 	fi
 done

--- a/go-gofumpt.sh
+++ b/go-gofumpt.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+cmd=(gofumpt)
+
+OPTIONS=(-w)
+# If arg doesn't pass [ -f ] check, then it is assumed to be an option
+#
+while [ $# -gt 0 ] && [ "$1" != "-" ] && [ "$1" != "--" ] && [ ! -f "$1" ]; do
+	OPTIONS+=("$1")
+	shift
+done
+
+FILES=()
+# Assume start of file list (may still be options)
+#
+while [ $# -gt 0 ] && [ "$1" != "-" ] && [ "$1" != "--" ]; do
+	FILES+=("$1")
+	shift
+done
+
+# If '--' next, then files = options
+#
+if [ $# -gt 0 ]; then
+	if [ "$1" == "-" ] || [ "$1" == "--" ]; then
+		shift
+		# Append to previous options
+		#
+		OPTIONS=("${OPTIONS[@]}" "${FILES[@]}")
+		FILES=()
+	fi
+fi
+
+# Any remaining arguments are assumed to be files
+#
+while [ $# -gt 0 ]; do
+	FILES+=("$1")
+	shift
+done
+
+errCode=0
+for file in "${FILES[@]}"; do
+	output=$("${cmd[@]}" "${OPTIONS[@]}" "${file}" 2>&1)
+	if [ ! -z "${output}" ]; then
+		echo -n "${output}"
+		echo "" # newline
+		errCode=1
+	fi
+done
+exit $errCode

--- a/go-imports.sh
+++ b/go-imports.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-cmd=(goimports -l -d)
+cmd=(goimports)
 
-OPTIONS=()
+OPTIONS=(-w)
 # If arg doesn't pass [ -f ] check, then it is assumed to be an option
 #
 while [ $# -gt 0 ] && [ "$1" != "-" ] && [ "$1" != "--" ] && [ ! -f "$1" ]; do


### PR DESCRIPTION
If you're running go-build* on windows, `/dev/null` doesn't exist so the hook fails.
With this change, a temporary directory is created for the output of go build.