### PR TITLE
removes ./... from my-cmd hooks; adds go mod tidy, gofump, -repo hooks for formatters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         files: \.(sh|bash)$
         types: [file]
         alias: shck
-        args: [ '-x', '-e', 'SC2033' ]
+        args: [ '-x', '-e', 'SC2034' ]
       # shfmt
       #
       - id: shfmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         files: \.(sh|bash)$
         types: [file]
         alias: shck
-        args: [ '-x' ]
+        args: [ '-x', '-e', 'SC2033' ]
       # shfmt
       #
       - id: shfmt

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -210,6 +210,8 @@
 # go-fumpt
 #   * File-based
 #   * Executes if any .go files modified
+# NOTES:
+#   Replaces go-fmt
 # ==============================================================================
 -   id: go-fumpt
     name: 'go-fumpt'
@@ -226,7 +228,7 @@
 #   * Recursive
 #   * Executes if any .go files modified
 # NOTES:
-#   `go fmt` delegates to `gofmt`, so we'll invote `gofmt` directly.
+#   Replaces go-fmt-repo
 # ==============================================================================
 -   id: go-fumpt-repo
     name: 'go-fumpt-repo'
@@ -242,7 +244,7 @@
 #   * File-based
 #   * Executes if any .go files modified
 # NOTES:
-#   Replaces go-fmt-fix
+#   Replaces go-fmt
 # ==============================================================================
 -   id: go-imports
     name: 'go-imports'
@@ -252,6 +254,23 @@
     language: 'script'
     description: "Run 'goimports -l -d [$ARGS] $FILE' for each staged .go file"
     pass_filenames: true
+
+# ==============================================================================
+# go-imports-repo
+#   * Repo-Based
+#   * Recursive
+#   * Executes if any .go files modified
+# NOTES:
+#   Replaces go-fmt-repo
+# ==============================================================================
+-   id: go-imports-repo
+    name: 'go-imports-repo'
+    entry: go-imports-repo.sh
+    types: [go]
+    exclude: '(^|/)vendor/'
+    language: 'script'
+    description: "Run 'goimports -l -d [$ARGS] .' in repo root folder"
+    pass_filenames: false
 
 # ==============================================================================
 # go-lint
@@ -307,7 +326,7 @@
 #   * File-based
 #   * Executes if any .go files modified
 # NOTES:
-#   Replaces go-imports-fix & go-fmt-fix
+#   Replaces go-imports & go-fmt
 # ==============================================================================
 -   id: go-returns
     name: 'go-returns'
@@ -317,6 +336,23 @@
     language: 'script'
     description: "Run 'goreturns -l -d [$ARGS] $FILE' for each staged .go file"
     pass_filenames: true
+
+# ==============================================================================
+# go-returns-repo
+#   * Repo-Based
+#   * Recursive
+#   * Executes if any .go files modified
+# NOTES:
+#   Replaces go-imports-repo & go-fmt-repo
+# ==============================================================================
+-   id: go-returns-repo
+    name: 'go-returns-repo'
+    entry: go-returns-repo.sh
+    types: [go]
+    exclude: '(^|/)vendor/'
+    language: 'script'
+    description: "Run 'goreturns -l -d [$ARGS] .' in repo root folder"
+    pass_filenames: false
 
 # ==============================================================================
 # go-revive

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -190,6 +190,54 @@
     pass_filenames: true
 
 # ==============================================================================
+# go-fmt-repo
+#   * Repo-Based
+#   * Recursive
+#   * Executes if any .go files modified
+# NOTES:
+#   `go fmt` delegates to `gofmt`, so we'll invote `gofmt` directly.
+# ==============================================================================
+-   id: go-fmt-repo
+    name: 'go-fmt-repo'
+    entry: go-fmt-repo.sh
+    types: [go]
+    exclude: '(^|/)vendor/'
+    language: 'script'
+    description: "Run 'gofmt -l -d [$ARGS] .' in repo root folder"
+    pass_filenames: false
+
+# ==============================================================================
+# go-fumpt
+#   * File-based
+#   * Executes if any .go files modified
+# ==============================================================================
+-   id: go-fumpt
+    name: 'go-fumpt'
+    entry: go-fumpt.sh
+    types: [go]
+    exclude: '(^|/)vendor/'
+    language: 'script'
+    description: "Run 'fumpt -l -d [$ARGS] $FILE' for each staged .go file"
+    pass_filenames: true
+
+# ==============================================================================
+# go-fumpt-repo
+#   * Repo-Based
+#   * Recursive
+#   * Executes if any .go files modified
+# NOTES:
+#   `go fmt` delegates to `gofmt`, so we'll invote `gofmt` directly.
+# ==============================================================================
+-   id: go-fumpt-repo
+    name: 'go-fumpt-repo'
+    entry: go-fumpt-repo.sh
+    types: [go]
+    exclude: '(^|/)vendor/'
+    language: 'script'
+    description: "Run 'fumpt -l -d [$ARGS] .' in repo root folder"
+    pass_filenames: false
+
+# ==============================================================================
 # go-imports
 #   * File-based
 #   * Executes if any .go files modified
@@ -218,6 +266,41 @@
     language: 'script'
     description: "Run 'golint -set_exit_status [$ARGS] $FILE' for each staged .go file"
     pass_filenames: true
+
+# ==============================================================================
+# go-mod-tidy
+#   * Folder-Based
+#   * Recursive
+#   * Targets first parent folder with a go.mod file
+#   * Executes if any .go files modified
+#   * Executes if go.mod modified
+# ==============================================================================
+-   id: go-mod-tidy
+    name: 'go-mod-tidy'
+    entry: go-mod-tidy.sh
+    files: '(\.go$)|(\bgo\.mod$)'
+    exclude: '(^|/)vendor/'
+    language: 'script'
+    description: "Run 'cd $(mod_root $FILE); go mod tidy [$ARGS]' for each staged .go file"
+    pass_filenames: true
+    require_serial: true
+
+# ==============================================================================
+# go-mod-tidy-repo
+#   * Repo-Based
+#   * Recursive
+#   * Targets ALL folders with a go.mod file
+#   * Executes if any .go files modified
+#   * Executes if go.mod modified
+# ==============================================================================
+-   id: go-mod-tidy-repo
+    name: 'go-mod-tidy-repo'
+    entry: go-mod-tidy-repo.sh
+    files: '(\.go$)|(\bgo\.mod$)'
+    exclude: '(^|/)vendor/'
+    language: 'script'
+    description: "Run 'cd $(mod_root); go mod tidy [$ARGS]' for each module in the repo"
+    pass_filenames: false
 
 # ==============================================================================
 # go-returns

--- a/README.md
+++ b/README.md
@@ -524,7 +524,9 @@ Using the `my-cmd-*` hooks, you can invoke custom go tools in various contexts.
 
 #### Configuring the hooks
 
-The my-cmd hooks are configured **entirely** through the pre-commit `args` attribute, including specifying which tool to run (ie `$ARGS[0]` above)
+The my-cmd hooks are configured **entirely** through the pre-commit `args` attribute, including specifying which tool to run (ie `$ARGS[0]` above).
+
+This includes the need to manually add the `./...` target for module-based tools that require it.
 
 #### Examples
 
@@ -538,7 +540,7 @@ _.pre-commit-config.yaml_
         -   id: my-cmd-mod
             name: go-test-mod
             alias: go-test-mod
-            args: [ go, test ]
+            args: [ go, test, ./... ]
 ```
 
 ##### Names &amp; Aliases

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ You can copy/paste the following snippet into your `.pre-commit-config.yaml` fil
     -   id: go-build-repo-mod
     -   id: go-build-repo-pkg
     #
+    # Go Mod Tidy
+    #
+    -   id: go-mod-tidy
+    -   id: go-mod-tidy-repo
+    #
     # Go Test
     #
     -   id: go-test-mod
@@ -70,8 +75,13 @@ You can copy/paste the following snippet into your `.pre-commit-config.yaml` fil
     # Formatters
     #
     -   id: go-fmt
-    -   id: go-imports # replaces go-fmt
-    -   id: go-returns # replaces go-imports & go-fmt
+    -   id: go-fmt-repo
+    -   id: go-fumpt        # replaces go-fmt
+    -   id: go-fumpt-repo   # replaces go-fmt-repo
+    -   id: go-imports      # replaces go-fmt
+    -   id: go-imports-repo # replaces go-fmt-repo
+    -   id: go-returns      # replaces go-imports & go-fmt
+    -   id: go-returns-repo # replaces go-imports-repo & go-fmt-repo
     #
     # Style Checkers
     #
@@ -92,7 +102,7 @@ You can copy/paste the following snippet into your `.pre-commit-config.yaml` fil
     #
     # Invoking Custom Go Tools
     # - Configured *entirely* through the `args` attribute, ie:
-    #   args: [ go, test ]
+    #   args: [ go, test, ./... ]
     # - Use the `name` attribute to provide better messaging when the hook runs
     # - Use the `alias` attribute to be able invoke your hook via `pre-commit run`
     #
@@ -197,13 +207,16 @@ This can be useful, for example, for hooks that display warnings, but don't gene
 --------
 ## Hooks
 
- - Correctness Checkers
+ - Build Tools
    - [go-build](#go-build)
+   - [go-mod-tidy](#go-mod-tidy)
+ - Correctness Checkers
    - [go-test](#go-test)
    - [go-vet](#go-vet)
    - [go-sec](#go-sec)
  - Formatters
    - [go-fmt](#go-fmt)
+   - [go-fumpt](#go-fumpt)
    - [go-imports](#go-imports)
    - [go-returns](#go-returns)
  - Style Checkers
@@ -233,9 +246,25 @@ Comes with Golang ( [golang.org](https://golang.org/) )
  - https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies
  - `go help build`
 
+---------------
+### go-mod-tidy
+Makes sure `go.mod` matches the source code in the module.
+
+| Hook ID            | Description
+|--------------------|------------
+| `go-mod-tidy`      | Run `'cd $(mod_root $FILE); go mod tidy [$ARGS] ./...'` for each staged .go file
+| `go-mod-tidy-repo` | Run `'cd $(mod_root); go mod tidy [$ARGS] ./...'` for each module in the repo
+
+##### Install
+Comes with Golang ( [golang.org](https://golang.org/) )
+
+##### Help
+ - https://golang.org/ref/mod#go-mod-tidy
+ - `go mod help tidy`
+
 -----------
 ### go-test
-Automates testing, printing a summary of test resutls.
+Automates testing, printing a summary of test results.
 
 | Hook ID            | Description
 |--------------------|------------
@@ -299,16 +328,17 @@ Formats Go programs. It uses tabs for indentation and blanks for alignment. Alig
 
  - Can modify files (see `-w`)
 
-| Hook ID  | Description
-|----------|------------
-| `go-fmt` | Run `'gofmt -l -d [$ARGS] $FILE'` for each staged .go file
+| Hook ID       | Description
+|---------------|------------
+| `go-fmt`      | Run `'gofmt -l -d [$ARGS] $FILE'` for each staged .go file
+| `go-fmt-repo` | Run `'gofmt -l -d [$ARGS] .'` in repo root folder
 
 ##### Install
 Comes with Golang ( [golang.org](https://golang.org/) )
 
 ##### Useful Args
 ```
--d=false : Don't display diffs
+-d=false : Hide diffs
 -s       : Try to simplify code
 -w       : Update source file directly
 ```
@@ -317,6 +347,35 @@ Comes with Golang ( [golang.org](https://golang.org/) )
  - https://godoc.org/github.com/golang/go/src/cmd/gofmt
  - `gofmt -h`
 
+------------
+### go-fumpt
+Enforce a stricter format than `gofmt`, while being backwards compatible.
+
+ - Replaces `go-fmt`
+ - Can modify files (see `-w`)
+
+| Hook ID         | Description
+|-----------------|------------
+| `go-fumpt`      | Run `'gofumpt -l -d [$ARGS] $FILE'` for each staged .go file
+| `go-fumpt-repo` | Run `'gofumpt -l -d [$ARGS] .'` in repo root folder
+
+##### Install (via [bingo](https://github.com/TekWizely/bingo))
+```
+bingo install mvdan.cc/gofumpt
+```
+
+##### Useful Args
+```
+-d=false : Hide diffs
+-extra   : Enable extra rules which should be vetted by a human
+-s       : Try to simplify code
+-w       : Update source file directly
+```
+
+##### Help
+ - https://pkg.go.dev/mvdan.cc/gofumpt
+ - `gofumpt -h`
+
 --------------
 ### go-imports
 Updates your Go import lines, adding missing ones and removing unreferenced ones.
@@ -324,9 +383,10 @@ Updates your Go import lines, adding missing ones and removing unreferenced ones
  - Replaces `go-fmt`
  - Can modify files (see `-w`)
 
-| Hook ID      | Description
-|--------------|------------
-| `go-imports` | Run `'goimports -l -d [$ARGS] $FILE'` for each staged .go file
+| Hook ID           | Description
+|-------------------|------------
+| `go-imports`      | Run `'goimports -l -d [$ARGS] $FILE'` for each staged .go file
+| `go-imports-repo` | Run `'goimports -l -d [$ARGS] .'` in repo root folder
 
 ##### Install (via [bingo](https://github.com/TekWizely/bingo))
 ```
@@ -354,9 +414,10 @@ Implements a Go pretty-printer (like `go-fmt`) that also adds zero-value return 
  - Replaces `go-fmt` and `go-imports`
  - Can modify files (see `-w`)
 
-| Hook ID      | Description
-|--------------|------------
-| `go-returns` | Run `'goreturns -l -d [$ARGS] $FILE'` for each staged .go file
+| Hook ID           | Description
+|-------------------|------------
+| `go-returns`      | Run `'goreturns -l -d [$ARGS] $FILE'` for each staged .go file
+| `go-returns-repo` | Run `'goreturns -l -d [$ARGS] .'` in repo root folder
 
 ##### Install (via [bingo](https://github.com/TekWizely/bingo))
 ```
@@ -516,11 +577,11 @@ Using the `my-cmd-*` hooks, you can invoke custom go tools in various contexts.
  | Hook ID           | Description
  |-------------------|------------
  | `my-cmd`          | Run `'$ARGS[0] [$ARGS[1:]] $FILE'` for each staged .go file
- | `my-cmd-mod`      | Run `'cd $(mod_root $FILE); $ARGS[0] [$ARGS[1:]] ./...'` for each staged .go file
- | `my-cmd-pkg`      | Run `'$ARGS[0] [$ARGS[1:]] ./$(dirname $FILE)'` for each staged .go file
+ | `my-cmd-mod`      | Run `'cd $(mod_root $FILE); GO111MODULE=on $ARGS[0] [$ARGS[1:]]'` for each staged .go file
+ | `my-cmd-pkg`      | Run `'GO111MODULE=off $ARGS[0] [$ARGS[1:]] ./$(dirname $FILE)'` for each staged .go file
  | `my-cmd-repo`     | Run `'$ARGS[0] [$ARGS[1:]]'` in the repo root folder
- | `my-cmd-repo-mod` | Run `'cd $(mod_root); $ARGS[0] [$ARGS[1:]] /...'` for each module in the repo
- | `my-cmd-repo-pkg` | Run `'$ARGS[0] [$ARGS[1:]] ./...'` in repo root folder
+ | `my-cmd-repo-mod` | Run `'cd $(mod_root); GO111MODULE=on $ARGS[0] [$ARGS[1:]]'` for each module in the repo
+ | `my-cmd-repo-pkg` | Run `'GO111MODULE=off $ARGS[0] [$ARGS[1:]]` in repo root folder
 
 #### Configuring the hooks
 

--- a/go-build-mod.sh
+++ b/go-build-mod.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(go build -o /dev/null)
-# shellcheck source=lib/cmd-mod.bash
 . "$(dirname "${0}")/lib/cmd-mod.bash"

--- a/go-build-pkg.sh
+++ b/go-build-pkg.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(go build -o /dev/null)
-# shellcheck source=lib/cmd-pkg.bash
 . "$(dirname "${0}")/lib/cmd-pkg.bash"

--- a/go-build-repo-mod.sh
+++ b/go-build-repo-mod.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(go build -o /dev/null)
-# shellcheck source=lib/cmd-repo-mod.bash
 . "$(dirname "${0}")/lib/cmd-repo-mod.bash"

--- a/go-build-repo-pkg.sh
+++ b/go-build-repo-pkg.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(go build -o /dev/null)
-# shellcheck source=lib/cmd-repo-pkg.bash
 . "$(dirname "${0}")/lib/cmd-repo-pkg.bash"

--- a/go-critic.sh
+++ b/go-critic.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(gocritic check)
-# shellcheck source=lib/cmd-files.bash
 . "$(dirname "${0}")/lib/cmd-files.bash"

--- a/go-fmt-repo.sh
+++ b/go-fmt-repo.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
-. "$(dirname "${0}")/lib/prepare-my-cmd.bash"
+error_on_output=1
+cmd=(gofmt -l -d .)
 . "$(dirname "${0}")/lib/cmd-repo.bash"

--- a/go-fmt.sh
+++ b/go-fmt.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
 error_on_output=1
 cmd=(gofmt -l -d)
-# shellcheck source=lib/cmd-files.bash
 . "$(dirname "${0}")/lib/cmd-files.bash"

--- a/go-fumpt-repo.sh
+++ b/go-fumpt-repo.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 error_on_output=1
-cmd=(goreturns -l -d)
+cmd=(gofumpt -l -d)
 . "$(dirname "${0}")/lib/cmd-files.bash"

--- a/go-fumpt-repo.sh
+++ b/go-fumpt-repo.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 error_on_output=1
-cmd=(gofumpt -l -d)
-. "$(dirname "${0}")/lib/cmd-files.bash"
+cmd=(gofumpt -l -d .)
+. "$(dirname "${0}")/lib/cmd-repo.bash"

--- a/go-fumpt.sh
+++ b/go-fumpt.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 error_on_output=1
-cmd=(goreturns -l -d)
+cmd=(gofumpt -l -d)
 . "$(dirname "${0}")/lib/cmd-files.bash"

--- a/go-imports-repo.sh
+++ b/go-imports-repo.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+error_on_output=1
+cmd=(goimports -l -d .)
+. "$(dirname "${0}")/lib/cmd-repo.bash"

--- a/go-imports.sh
+++ b/go-imports.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
 error_on_output=1
 cmd=(goimports -l -d)
-# shellcheck source=lib/cmd-files.bash
 . "$(dirname "${0}")/lib/cmd-files.bash"

--- a/go-lint.sh
+++ b/go-lint.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(golint -set_exit_status)
-# shellcheck source=lib/cmd-files.bash
 . "$(dirname "${0}")/lib/cmd-files.bash"

--- a/go-mod-tidy-repo.sh
+++ b/go-mod-tidy-repo.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
-cmd=(revive)
+use_dot_dot_dot=0
+cmd=(go mod tidy)
 . "$(dirname "${0}")/lib/cmd-repo-mod.bash"

--- a/go-mod-tidy.sh
+++ b/go-mod-tidy.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
-. "$(dirname "${0}")/lib/prepare-my-cmd.bash"
+use_dot_dot_dot=0
+cmd=(go mod tidy)
 . "$(dirname "${0}")/lib/cmd-mod.bash"

--- a/go-returns-repo.sh
+++ b/go-returns-repo.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+error_on_output=1
+cmd=(goreturns -l -d .)
+. "$(dirname "${0}")/lib/cmd-repo.bash"

--- a/go-revive-mod.sh
+++ b/go-revive-mod.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(revive)
-# shellcheck source=lib/cmd-mod.bash
 . "$(dirname "${0}")/lib/cmd-mod.bash"

--- a/go-revive.sh
+++ b/go-revive.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(revive)
-# shellcheck source=lib/cmd-files.bash
 . "$(dirname "${0}")/lib/cmd-files.bash"

--- a/go-sec-mod.sh
+++ b/go-sec-mod.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(gosec)
-# shellcheck source=lib/cmd-mod.bash
 . "$(dirname "${0}")/lib/cmd-mod.bash"

--- a/go-sec-pkg.sh
+++ b/go-sec-pkg.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(gosec)
-# shellcheck source=lib/cmd-pkg.bash
 . "$(dirname "${0}")/lib/cmd-pkg.bash"

--- a/go-sec-repo-mod.sh
+++ b/go-sec-repo-mod.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(gosec)
-# shellcheck source=lib/cmd-repo-mod.bash
 . "$(dirname "${0}")/lib/cmd-repo-mod.bash"

--- a/go-sec-repo-pkg.sh
+++ b/go-sec-repo-pkg.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(gosec)
-# shellcheck source=lib/cmd-repo-pkg.bash
 . "$(dirname "${0}")/lib/cmd-repo-pkg.bash"

--- a/go-test-mod.sh
+++ b/go-test-mod.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(go test)
-# shellcheck source=lib/cmd-mod.bash
 . "$(dirname "${0}")/lib/cmd-mod.bash"

--- a/go-test-pkg.sh
+++ b/go-test-pkg.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(go test)
-# shellcheck source=lib/cmd-pkg.bash
 . "$(dirname "${0}")/lib/cmd-pkg.bash"

--- a/go-test-repo-mod.sh
+++ b/go-test-repo-mod.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(go test)
-# shellcheck source=lib/cmd-repo-mod.bash
 . "$(dirname "${0}")/lib/cmd-repo-mod.bash"

--- a/go-test-repo-pkg.sh
+++ b/go-test-repo-pkg.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(go test)
-# shellcheck source=lib/cmd-repo-pkg.bash
 . "$(dirname "${0}")/lib/cmd-repo-pkg.bash"

--- a/go-vet-mod.sh
+++ b/go-vet-mod.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(go vet)
-# shellcheck source=lib/cmd-mod.bash
 . "$(dirname "${0}")/lib/cmd-mod.bash"

--- a/go-vet-pkg.sh
+++ b/go-vet-pkg.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(go vet)
-# shellcheck source=lib/cmd-pkg.bash
 . "$(dirname "${0}")/lib/cmd-pkg.bash"

--- a/go-vet-repo-mod.sh
+++ b/go-vet-repo-mod.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(go vet)
-# shellcheck source=lib/cmd-repo-mod.bash
 . "$(dirname "${0}")/lib/cmd-repo-mod.bash"

--- a/go-vet-repo-pkg.sh
+++ b/go-vet-repo-pkg.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(go vet)
-# shellcheck source=lib/cmd-repo-pkg.bash
 . "$(dirname "${0}")/lib/cmd-repo-pkg.bash"

--- a/go-vet.sh
+++ b/go-vet.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(go vet)
-# shellcheck source=lib/cmd-files.bash
 . "$(dirname "${0}")/lib/cmd-files.bash"

--- a/golangci-lint-mod.sh
+++ b/golangci-lint-mod.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(golangci-lint run)
-# shellcheck source=lib/cmd-mod.bash
 . "$(dirname "${0}")/lib/cmd-mod.bash"

--- a/golangci-lint-pkg.sh
+++ b/golangci-lint-pkg.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(golangci-lint run)
-# shellcheck source=lib/cmd-pkg.bash
 . "$(dirname "${0}")/lib/cmd-pkg.bash"

--- a/golangci-lint-repo-mod.sh
+++ b/golangci-lint-repo-mod.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(golangci-lint run)
-# shellcheck source=lib/cmd-repo-mod.bash
 . "$(dirname "${0}")/lib/cmd-repo-mod.bash"

--- a/golangci-lint-repo-pkg.sh
+++ b/golangci-lint-repo-pkg.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(golangci-lint run)
-# shellcheck source=lib/cmd-repo-pkg.bash
 . "$(dirname "${0}")/lib/cmd-repo-pkg.bash"

--- a/golangci-lint.sh
+++ b/golangci-lint.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # vars used by sourced script
-error_on_output=0
 cmd=(golangci-lint run)
-# shellcheck source=lib/cmd-files.bash
 . "$(dirname "${0}")/lib/cmd-files.bash"

--- a/lib/cmd-mod.bash
+++ b/lib/cmd-mod.bash
@@ -4,6 +4,9 @@
 
 prepare_file_hook_cmd "$@"
 
+if [ "${use_dot_dot_dot:-}" -eq 1 ]; then
+	OPTIONS+=('./...')
+fi
 export GO111MODULE=on
 error_code=0
 # Assume parent folder of go.mod is module root folder
@@ -11,12 +14,12 @@ error_code=0
 for sub in $(find_module_roots "${FILES[@]}" | sort -u); do
 	pushd "${sub}" > /dev/null || exit 1
 	if [ "${error_on_output:-}" -eq 1 ]; then
-		output=$("${cmd[@]}" "${OPTIONS[@]}" ./... 2>&1)
+		output=$("${cmd[@]}" "${OPTIONS[@]}" 2>&1)
 		if [ -n "${output}" ]; then
 			printf "%s\n" "${output}"
 			error_code=1
 		fi
-	elif ! "${cmd[@]}" "${OPTIONS[@]}" ./...; then
+	elif ! "${cmd[@]}" "${OPTIONS[@]}"; then
 		error_code=1
 	fi
 	popd > /dev/null || exit 1

--- a/lib/cmd-repo-mod.bash
+++ b/lib/cmd-repo-mod.bash
@@ -4,6 +4,9 @@
 
 prepare_repo_hook_cmd "$@"
 
+if [ "${use_dot_dot_dot:-}" -eq 1 ]; then
+	OPTIONS+=('./...')
+fi
 export GO111MODULE=on
 error_code=0
 # Assume parent folder of go.mod is module root folder
@@ -11,12 +14,12 @@ error_code=0
 for sub in $(find . -name go.mod -not -path '*/vendor/*' -exec dirname "{}" ';' | sort -u); do
 	pushd "${sub}" > /dev/null || exit 1
 	if [ "${error_on_output:-}" -eq 1 ]; then
-		output=$("${cmd[@]}" "${OPTIONS[@]}" ./... 2>&1)
+		output=$("${cmd[@]}" "${OPTIONS[@]}" 2>&1)
 		if [ -n "${output}" ]; then
 			printf "%s\n" "${output}"
 			error_code=1
 		fi
-	elif ! "${cmd[@]}" "${OPTIONS[@]}" ./...; then
+	elif ! "${cmd[@]}" "${OPTIONS[@]}"; then
 		error_code=1
 	fi
 	popd > /dev/null || exit 1

--- a/lib/cmd-repo-pkg.bash
+++ b/lib/cmd-repo-pkg.bash
@@ -6,7 +6,7 @@ prepare_repo_hook_cmd "$@"
 
 export GO111MODULE=off
 if [ "${error_on_output:-}" -eq 1 ]; then
-	output=$("${cmd[@]}" "${OPTIONS[@]}" ./... 2>&1)
+	output=$("${cmd[@]}" "${OPTIONS[@]}" 2>&1)
 	if [ -n "${output}" ]; then
 		printf "%s\n" "${output}"
 		exit 1

--- a/lib/cmd-repo-pkg.bash
+++ b/lib/cmd-repo-pkg.bash
@@ -6,7 +6,7 @@ prepare_repo_hook_cmd "$@"
 
 export GO111MODULE=off
 if [ "${error_on_output:-}" -eq 1 ]; then
-	output=$("${cmd[@]}" "${OPTIONS[@]}" 2>&1)
+	output=$("${cmd[@]}" "${OPTIONS[@]}" ./... 2>&1)
 	if [ -n "${output}" ]; then
 		printf "%s\n" "${output}"
 		exit 1

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -1,5 +1,8 @@
 # shellcheck shell=bash
 
+: "${use_dot_dot_dot:=1}"
+: "${error_on_output:=0}"
+
 ##
 # prepare_repo_hook_cmd
 #

--- a/lib/prepare-my-cmd.bash
+++ b/lib/prepare-my-cmd.bash
@@ -1,10 +1,16 @@
 # shellcheck shell=bash
-# shellcheck disable=SC2034  # vars used by lib/cmd-* scripts
-error_on_output=0
-if [ "${1:-}" == "--error-on-output" ]; then
-	error_on_output=1
-	shift
-fi
+use_dot_dot_dot=0
+while (($#)); do
+	case "$1" in
+		--error-on-output)
+			error_on_output=1
+			shift
+			;;
+		*)
+			break
+			;;
+	esac
+done
 cmd=()
 if [ -n "${1:-}" ]; then
 	cmd+=("${1}")

--- a/my-cmd-pkg.sh
+++ b/my-cmd-pkg.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck source=lib/prepare-my-cmd.bash
 . "$(dirname "${0}")/lib/prepare-my-cmd.bash"
-# shellcheck source=lib/cmd-pkg.bash
 . "$(dirname "${0}")/lib/cmd-pkg.bash"

--- a/my-cmd-repo-mod.sh
+++ b/my-cmd-repo-mod.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck source=lib/prepare-my-cmd.bash
 . "$(dirname "${0}")/lib/prepare-my-cmd.bash"
-# shellcheck source=lib/cmd-repo-mod.bash
 . "$(dirname "${0}")/lib/cmd-repo-mod.bash"

--- a/my-cmd-repo-pkg.sh
+++ b/my-cmd-repo-pkg.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck source=lib/prepare-my-cmd.bash
 . "$(dirname "${0}")/lib/prepare-my-cmd.bash"
-# shellcheck source=lib/cmd-repo-pkg.bash
 . "$(dirname "${0}")/lib/cmd-repo-pkg.bash"

--- a/my-cmd.sh
+++ b/my-cmd.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
-# shellcheck source=lib/prepare-my-cmd.bash
 . "$(dirname "${0}")/lib/prepare-my-cmd.bash"
-# shellcheck source=lib/cmd-files.bash
 . "$(dirname "${0}")/lib/cmd-files.bash"

--- a/sample-config.yaml
+++ b/sample-config.yaml
@@ -87,6 +87,11 @@ repos:
     -   id: go-build-repo-mod
     -   id: go-build-repo-pkg
     #
+    # Go Mod Tidy
+    #
+    -   id: go-mod-tidy
+    -   id: go-mod-tidy-repo
+    #
     # Go Test
     #
     -   id: go-test-mod
@@ -118,8 +123,13 @@ repos:
     # Formatters
     #
     -   id: go-fmt
-    -   id: go-imports # Replaces go-fmt
-    -   id: go-returns # Replaces go-imports & go-fmt
+    -   id: go-fmt-repo
+    -   id: go-fumpt        # replaces go-fmt
+    -   id: go-fumpt-repo   # replaces go-fmt-repo
+    -   id: go-imports      # replaces go-fmt
+    -   id: go-imports-repo # replaces go-fmt-repo
+    -   id: go-returns      # replaces go-imports & go-fmt
+    -   id: go-returns-repo # replaces go-imports-repo & go-fmt-repo
     #
     # Style Checkers
     #
@@ -140,7 +150,7 @@ repos:
     #
     # Invoking Custom Go Tools
     # - Configured *entirely* through the `args` attribute, ie:
-    #   args: [ go, test ]
+    #   args: [ go, test, ./... ]
     # - Use the `name` attribute to provide better messaging when the hook runs
     # - Use the `alias` attribute to be able invoke your hook via `pre-commit run`
     #


### PR DESCRIPTION
* Removes default ./... arg from my-cmd hooks
* Adds support go mod tidy
* Adds support for gofumpt
* Adds -repo hooks for formatters:
  - go-fmt-repo
  - go-frumpt-repo
  - go-imports-repo
  - go-returns-repo 
* Simplifies .sh scripts:
  - Sets "error_on_output=0" globally by default
  - Disable SC2034 (unused args) globally
  - Removes "error_on_output=0" lines
  - Removes "shellcheck disable=SC2034" lines
  - Removes "shellcheck source=" lines

BREAKING CHANGE: my-cmd-mod, my-cmd-mod-repo, and my-cmd-pkg hooks no-longer auto-add ./... argument
