### PR TITLE
feat: pass module dir as `--path-prefix` arg to golangci-lint

### DIFF
--- a/golangci-lint-mod.sh
+++ b/golangci-lint-mod.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 cmd=(golangci-lint run)
+cmd_pwd_arg="--path-prefix"
 . "$(dirname "${0}")/lib/cmd-mod.bash"

--- a/golangci-lint-repo-mod.sh
+++ b/golangci-lint-repo-mod.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 cmd=(golangci-lint run)
+cmd_pwd_arg="--path-prefix"
 . "$(dirname "${0}")/lib/cmd-repo-mod.bash"

--- a/lib/cmd-mod.bash
+++ b/lib/cmd-mod.bash
@@ -14,6 +14,9 @@ error_code=0
 #
 for sub in $(find_module_roots "${FILES[@]}" | sort -u); do
 	pushd "${sub}" > /dev/null || exit 1
+	if [ "${cmd_pwd_arg:-}" ]; then
+		OPTIONS+=("${cmd_pwd_arg}=${sub}")
+	fi
 	if [ "${error_on_output:-}" -eq 1 ]; then
 		output=$(/usr/bin/env "${ENV_VARS[@]}" "${cmd[@]}" "${OPTIONS[@]}" 2>&1)
 		if [ -n "${output}" ]; then

--- a/lib/cmd-repo-mod.bash
+++ b/lib/cmd-repo-mod.bash
@@ -14,6 +14,9 @@ error_code=0
 #
 for sub in $(find . -name go.mod -not -path '*/vendor/*' -exec dirname "{}" ';' | sort -u); do
 	pushd "${sub}" > /dev/null || exit 1
+	if [ "${cmd_pwd_arg:-}" ]; then
+		OPTIONS+=("${cmd_pwd_arg}=${sub}")
+	fi
 	if [ "${error_on_output:-}" -eq 1 ]; then
 		output=$(/usr/bin/env "${ENV_VARS[@]}" "${cmd[@]}" "${OPTIONS[@]}" 2>&1)
 		if [ -n "${output}" ]; then


### PR DESCRIPTION
This ensures that the path output reported by `golangci-lint` is qualified with respect to a given linted file's path within the repo. Without this option, just the filename itself is outputted, leading to ambiguity as to which file is problematic when multiple files have the same name (e.g. `main.go`).

The implementation creates a generic argument that can be used for any other commands that need the working directory passed to them during iteration.

----

Before:
```sh
main.go:10:9: unused-parameter: parameter 'request' seems to be unused, consider removing or renaming it as _ (revive)
```

After:
```sh
modules/compute/main.go:10:9: unused-parameter: parameter 'request' seems to be unused, consider removing or renaming it as _ (revive)
```