### PR TITLE
Adds --hook:ignore-file, --hook:ignore-dir

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         files: \.(sh|bash)$
         types: [file]
         alias: shck
-        args: [ '-x', '-e', 'SC2034' ]
+        args: [ '-x', '-P', 'SCRIPTDIR', '-e', 'SC2034' ]
       # shfmt
       #
       - id: shfmt

--- a/go-revive.sh
+++ b/go-revive.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 cmd=(revive)
 if [ -f "revive.toml" ]; then
-	cmd+=( "-config=revive.toml" )
+	cmd+=("-config=revive.toml")
 fi
-ignore_file_pattern_array=( "revive.toml" )
+ignore_pattern_array=("revive.toml")
 . "$(dirname "${0}")/lib/cmd-files.bash"

--- a/go-revive.sh
+++ b/go-revive.sh
@@ -3,5 +3,5 @@ cmd=(revive)
 if [ -f "revive.toml" ]; then
 	cmd+=("-config=revive.toml")
 fi
-ignore_pattern_array=("revive.toml")
+ignore_file_pattern_array=("revive.toml")
 . "$(dirname "${0}")/lib/cmd-files.bash"

--- a/lib/cmd-mod.bash
+++ b/lib/cmd-mod.bash
@@ -12,6 +12,7 @@ export GO111MODULE=on
 error_code=0
 # Assume parent folder of go.mod is module root folder
 #
+# TODO Try to reduce the redundancy by generating the dirname's first
 for sub in $(find_module_roots "${FILES[@]}" | sort -u); do
 	pushd "${sub}" > /dev/null || exit 1
 	if [ "${error_on_output:-}" -eq 1 ]; then

--- a/lib/cmd-repo-mod.bash
+++ b/lib/cmd-repo-mod.bash
@@ -13,10 +13,10 @@ error_code=0
 # Assume parent folder of go.mod is module root folder
 #
 for file in $(find . -name go.mod | sort -u); do
-  if is_path_ignored_by_dir_pattern "${file}" || is_path_ignored_by_file_pattern "${file}"; then
-    continue
-  fi
-  sub=$(dirname "${file}")
+	if is_path_ignored_by_dir_pattern "${file}" || is_path_ignored_by_pattern "${file}"; then
+		continue
+	fi
+	sub=$(dirname "${file}")
 	pushd "${sub}" > /dev/null || exit 1
 	if [ "${error_on_output:-}" -eq 1 ]; then
 		output=$(/usr/bin/env "${ENV_VARS[@]}" "${cmd[@]}" "${OPTIONS[@]}" 2>&1)

--- a/lib/cmd-repo-mod.bash
+++ b/lib/cmd-repo-mod.bash
@@ -12,7 +12,11 @@ export GO111MODULE=on
 error_code=0
 # Assume parent folder of go.mod is module root folder
 #
-for sub in $(find . -name go.mod -not -path '*/vendor/*' -exec dirname "{}" ';' | sort -u); do
+for file in $(find . -name go.mod | sort -u); do
+  if is_path_ignored_by_dir_pattern "${file}" || is_path_ignored_by_file_pattern "${file}"; then
+    continue
+  fi
+  sub=$(dirname "${file}")
 	pushd "${sub}" > /dev/null || exit 1
 	if [ "${error_on_output:-}" -eq 1 ]; then
 		output=$(/usr/bin/env "${ENV_VARS[@]}" "${cmd[@]}" "${OPTIONS[@]}" 2>&1)

--- a/lib/cmd-repo-mod.bash
+++ b/lib/cmd-repo-mod.bash
@@ -13,11 +13,11 @@ error_code=0
 # Assume parent folder of go.mod is module root folder
 #
 for file in $(find . -name go.mod | sort -u); do
-	if is_path_ignored_by_dir_pattern "${file}" || is_path_ignored_by_pattern "${file}"; then
+	file_dir=$(dirname "${file}")
+	if is_path_ignored_by_dir_pattern "${file_dir}" || is_path_ignored_by_file_pattern "${file}" || is_path_ignored_by_pattern "${file}"; then
 		continue
 	fi
-	sub=$(dirname "${file}")
-	pushd "${sub}" > /dev/null || exit 1
+	pushd "${file_dir}" > /dev/null || exit 1
 	if [ "${error_on_output:-}" -eq 1 ]; then
 		output=$(/usr/bin/env "${ENV_VARS[@]}" "${cmd[@]}" "${OPTIONS[@]}" 2>&1)
 		if [ -n "${output}" ]; then

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -355,6 +355,16 @@ function parse_repo_hook_args {
 				fi
 				shift
 				;;
+			--hook:ignore-file=*)
+				local ignore_file="${1#--hook:ignore-file=}"
+				if [[ -n "${ignore_file}" ]]; then
+					ignore_file_pattern_array+=("${ignore_file}")
+				else
+					printf "ERROR: Empty hook:ignore-file argument'\n" >&2
+					exit 1
+				fi
+				shift
+				;;
 			--hook:ignore-dir=*)
 				local ignore_dir="${1#--hook:ignore-dir=}"
 				if [[ -n "${ignore_dir}" ]]; then

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -200,7 +200,7 @@ is_path_ignored_by_dir_pattern() {
 # Creates global vars:
 #   ENV_VARS: List of variables to assign+export before invoking command
 #   OPTIONS : List of options to pass to command
-#   FILES   : List of files to process, filtered against ignored dir and pattern entries
+#   FILES   : List of files to process, filtered against ignored dir, file and pattern entries
 #
 # NOTE: We consume the first (optional) '--' we encounter.
 #       If you want to pass '--' to the command, you'll need to use 2 of them
@@ -300,7 +300,7 @@ function parse_file_hook_args {
 	#
 	all_files+=("$@")
 
-	# Filter out ignored dir and pattern entries
+	# Filter out ignored dir, file and pattern entries
 	#
 	FILES=()
 	local file


### PR DESCRIPTION
ignore-file patterns are based on simple bash pattern matching.

Vendor exclusions are now subject to the ignore-dir logic.


---

Relates to #23,  #24, #33, #37

cc: @balihb  Hoping you can help me test this.  I think you would add `--hook:ignore-dir=.cache` as an argument to your hook invocation.

I haven't even tested myself yet so this is very alpha-level :)
