### PR TITLE
feat(govulncheck): add support for govulncheck

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -757,6 +757,41 @@
     pass_filenames: true
 
 # ==============================================================================
+# go-vulncheck-mod
+#   * Folder-Based
+#   * Recursive
+#   * Targets first parent folder with a go.mod file
+#   * Executes if any .go files modified
+#   * Executes if go.mod modified
+# ==============================================================================
+-   id: go-vulncheck-mod
+    name: 'go-vulncheck-mod'
+    entry: go-vulncheck-mod.sh
+    files: '(\.go$)|(\bgo\.mod$)'
+    exclude: '(^|/)vendor/'
+    language: 'script'
+    description: "Run 'cd $(mod_root $FILE); govulncheck [$ARGS] ./...' for each staged .go file"
+    pass_filenames: true
+    require_serial: true
+
+# ==============================================================================
+# go-vulncheck-repo-mod
+#   * Repo-Based
+#   * Recursive
+#   * Targets ALL folders with a go.mod file
+#   * Executes if any .go files modified
+#   * Executes if go.mod modified
+# ==============================================================================
+-   id: go-vulncheck-repo-mod
+    name: 'go-vulncheck-repo-mod'
+    entry: go-vulncheck-repo-mod.sh
+    files: '(\.go$)|(\bgo\.mod$)'
+    exclude: '(^|/)vendor/'
+    language: 'script'
+    description: "Run 'cd $(mod_root); govulncheck [$ARGS] ./...' for each module in the repo"
+    pass_filenames: false
+
+# ==============================================================================
 # golangci-lint-mod
 #   * Folder-Based
 #   * Recursive

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ You can copy/paste the following snippet into your `.pre-commit-config.yaml` fil
     -   id: go-vet-repo-mod
     -   id: go-vet-repo-pkg
     #
+    # Go Vulncheck
+    # note: Only works with Go modules
+    #
+    -   id: go-vulncheck-mod
+    -   id: go-vulncheck-repo-mod
+    #
     # Revive
     #
     -   id: go-revive
@@ -402,6 +408,7 @@ This can be useful, for example, for hooks that display warnings, but don't gene
  - Correctness Checkers
    - [go-test](#go-test)
    - [go-vet](#go-vet)
+   - [go-vulncheck](#go-vulncheck)
    - [go-sec](#go-sec)
    - [go-staticcheck](#go-staticcheck)
    - [go-structslop](#go-structslop)
@@ -490,6 +497,28 @@ bingo install github.com/securego/gosec/v2/cmd/gosec
 ##### Help
  - https://github.com/securego/gosec#usage
  - `gosec (no args)`
+
+----------------
+### go-vulncheck
+Govulncheck reports known vulnerabilities that affect Go code. It uses static analysis of source code or a binary's symbol table to narrow down reports to only those that could affect the application.
+
+Govulncheck is an official Go tool. It is developed and maintained by the Go security team (which is part of the official Go development team at Google) and backed by the official Go Vulnerability Database.
+
+| Hook ID                 | Description                                                                      |
+|-------------------------|----------------------------------------------------------------------------------|
+| `go-vulncheck-mod`      | Run `'cd $(mod_root $FILE); govulncheck [$ARGS] ./...'` for each staged .go file |
+| `go-vulncheck-repo-mod` | Run `'cd $(mod_root); govulncheck [$ARGS] ./...'` for each module in the repo    |
+
+**NOTE:** Govulncheck only works with Go modules, hence only the `mod` hooks are implemented.
+
+##### Install (via [bingo](https://github.com/TekWizely/bingo))
+```
+bingo install golang.org/x/vuln/cmd/govulncheck
+```
+
+##### Help
+- https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck
+- `govulncheck -h`
 
 ------------------
 ### go-staticcheck

--- a/go-vulncheck-mod.sh
+++ b/go-vulncheck-mod.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+cmd=(govulncheck)
+printf_module_announce="\nChecking Module: %s\n\n"
+. "$(dirname "${0}")/lib/cmd-mod.bash"

--- a/go-vulncheck-repo-mod.sh
+++ b/go-vulncheck-repo-mod.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+cmd=(govulncheck)
+printf_module_announce="\nChecking Module: %s\n\n"
+. "$(dirname "${0}")/lib/cmd-repo-mod.bash"

--- a/lib/cmd-mod.bash
+++ b/lib/cmd-mod.bash
@@ -1,5 +1,7 @@
 # shellcheck shell=bash
 
+: "${printf_module_announce:=}" # printf template: '%s'
+
 # shellcheck source=./common.bash
 . "$(dirname "${0}")/lib/common.bash"
 
@@ -15,6 +17,10 @@ error_code=0
 # TODO Try to reduce the redundancy by generating the dirname's first
 for sub in $(find_module_roots "${FILES[@]}" | sort -u); do
 	pushd "${sub}" > /dev/null || exit 1
+	if [ -n "${printf_module_announce}" ]; then
+		# shellcheck disable=SC2059 # Using variable as printf template
+		printf -- "${printf_module_announce}" "${sub#./}"
+	fi
 	if [ "${error_on_output:-}" -eq 1 ]; then
 		output=$(/usr/bin/env "${ENV_VARS[@]}" "${cmd[@]}" "${OPTIONS[@]}" 2>&1)
 		if [ -n "${output}" ]; then

--- a/lib/cmd-repo-mod.bash
+++ b/lib/cmd-repo-mod.bash
@@ -1,5 +1,7 @@
 # shellcheck shell=bash
 
+: "${printf_module_announce:=}" # printf template: '%s'
+
 # shellcheck source=./common.bash
 . "$(dirname "${0}")/lib/common.bash"
 
@@ -17,7 +19,11 @@ for file in $(find . -name go.mod | sort -u); do
 	if is_path_ignored_by_dir_pattern "${file_dir}" || is_path_ignored_by_file_pattern "${file}" || is_path_ignored_by_pattern "${file}"; then
 		continue
 	fi
-	pushd "${file_dir}" > /dev/null || exit 1
+	pushd "${file_dir}" >/dev/null || exit 1
+	if [ -n "${printf_module_announce}" ]; then
+		# shellcheck disable=SC2059 # Using variable as printf template
+		printf -- "${printf_module_announce}" "${file_dir#./}"
+	fi
 	if [ "${error_on_output:-}" -eq 1 ]; then
 		output=$(/usr/bin/env "${ENV_VARS[@]}" "${cmd[@]}" "${OPTIONS[@]}" 2>&1)
 		if [ -n "${output}" ]; then
@@ -27,6 +33,6 @@ for file in $(find . -name go.mod | sort -u); do
 	elif ! /usr/bin/env "${ENV_VARS[@]}" "${cmd[@]}" "${OPTIONS[@]}"; then
 		error_code=1
 	fi
-	popd > /dev/null || exit 1
+	popd >/dev/null || exit 1
 done
 exit $error_code

--- a/sample-config.yaml
+++ b/sample-config.yaml
@@ -114,6 +114,12 @@ repos:
     -   id: go-vet-repo-mod
     -   id: go-vet-repo-pkg
     #
+    # Go Vulncheck
+    # note: Only works with Go modules
+    #
+    -   id: go-vulncheck-mod
+    -   id: go-vulncheck-repo-mod
+    #
     # Revive
     #
     -   id: go-revive


### PR DESCRIPTION
govulncheck only works on modules, so only the -mod and -repo-mod hooks were implemented.

Learn More:
* https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck

chore: Add support for custom printf template to announce module folders when running hooks that don't display what folder/module they are running against.

govulncheck doesn't (currently) display the folder when generating error messages, making the results confusing when running against multiple modules.

docs: Update README for govulncheck
docs: Update samples yaml files for govulncheck