### PR TITLE
fix: references to go-critic executable (renamed from gocritic)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -170,7 +170,7 @@
     types: [go]
     exclude: '(^|/)vendor/'
     language: 'script'
-    description: "Run 'gocritic check [$ARGS] $FILE' for each staged .go file"
+    description: "Run 'go-critic check [$ARGS] $FILE' for each staged .go file"
     pass_filenames: true
 
 # ==============================================================================

--- a/README.md
+++ b/README.md
@@ -774,9 +774,9 @@ You can use the `"verbose: true"` hook configuration to always show hook output.
 ### go-critic
 The most opinionated Go source code linter for code audit.
 
-| Hook ID     | Description                                                   |
-|-------------|---------------------------------------------------------------|
-| `go-critic` | Run `'gocritic check [$ARGS] $FILE'` for each staged .go file |
+| Hook ID     | Description                                                    |
+|-------------|----------------------------------------------------------------|
+| `go-critic` | Run `'go-critic check [$ARGS] $FILE'` for each staged .go file |
 
 ##### Install
    https://github.com/go-critic/go-critic#installation
@@ -798,7 +798,7 @@ The most opinionated Go source code linter for code audit.
 
 #### Help
  - https://go-critic.github.io/overview
- - `gocritic check -help`
+ - `go-critic check -help`
 
 -----------------
 ### golangci-lint

--- a/go-critic.sh
+++ b/go-critic.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-cmd=(gocritic check)
+cmd=(go-critic check)
 . "$(dirname "${0}")/lib/cmd-files.bash"


### PR DESCRIPTION
Update invocations and docs to use/reference `go-critic` to match upstream rename.

* https://github.com/go-critic/go-critic/pull/1482

---

Fixes #44 

cc: @aliceseaborn