### PR TITLE
feat(go-tool) Support for Go Tool Invocation

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -675,6 +675,70 @@
     pass_filenames: false
 
 # ==============================================================================
+# go-tool
+#   * File-based
+#   * Executes if any .go files modified
+# ==============================================================================
+-   id: go-tool
+    name: 'go-tool'
+    entry: go-tool.sh
+    types: [go]
+    exclude: '(^|/)vendor/'
+    language: 'script'
+    description: "Run 'go tool [$ARGS] $FILE' for each staged .go file"
+    pass_filenames: true
+
+# ==============================================================================
+# go-tool-mod
+#   * Folder-Based
+#   * Recursive
+#   * Targets first parent folder with a go.mod file
+#   * Executes if any .go files modified
+#   * Executes if go.mod modified
+# ==============================================================================
+-   id: go-tool-mod
+    name: 'go-tool-mod'
+    entry: go-tool-mod.sh
+    files: '(\.go$)|(\bgo\.mod$)'
+    exclude: '(^|/)vendor/'
+    language: 'script'
+    description: "Run 'cd $(mod_root $FILE); go tool [$ARGS]' for each staged .go file"
+    pass_filenames: true
+    require_serial: true
+
+# ==============================================================================
+# go-tool-repo
+#   * Repo-Based
+#   * Recursive
+#   * Executes if any .go files modified
+# ==============================================================================
+-   id: go-tool-repo
+    name: 'go-tool-repo'
+    entry: go-tool-repo.sh
+    types: [go]
+    exclude: '(^|/)vendor/'
+    language: 'script'
+    description: "Run 'go tool [$ARGS]' in the repo root folder"
+    pass_filenames: false
+
+# ==============================================================================
+# go-tool-repo-mod
+#   * Repo-Based
+#   * Recursive
+#   * Targets ALL folders with a go.mod file
+#   * Executes if any .go files modified
+#   * Executes if go.mod modified
+# ==============================================================================
+-   id: go-tool-repo-mod
+    name: 'go-tool-repo-mod'
+    entry: go-tool-repo-mod.sh
+    files: '(\.go$)|(\bgo\.mod$)'
+    exclude: '(^|/)vendor/'
+    language: 'script'
+    description: "Run 'cd $(mod_root); go tool [$ARGS]' for each module in the repo"
+    pass_filenames: false
+
+# ==============================================================================
 # go-vet-mod
 #   * Folder-Based
 #   * Recursive

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ You can copy/paste the following snippet into your `.pre-commit-config.yaml` fil
     #
     #           --hook:env:NAME=VALUE
     #
+    # NOTE: You can invoke hooks via 'go tool' using:
+    #
+    #           --hook:go-tool
+    #           --hook:go-tool-mod=MODFILE
+    #           --hook:go-tool-arg:ARG
+    #
     # Consider adding aliases to longer-named hooks for easier CLI usage.
     # ==========================================================================
 -   repo: https://github.com/tekwizely/pre-commit-golang
@@ -44,6 +50,13 @@ You can copy/paste the following snippet into your `.pre-commit-config.yaml` fil
     -   id: go-build-pkg
     -   id: go-build-repo-mod
     -   id: go-build-repo-pkg
+    #
+    # Go Tool (Go 1.24+)
+    #
+    -   id: go-tool
+    -   id: go-tool-mod
+    -   id: go-tool-repo
+    -   id: go-tool-repo-mod
     #
     # Go Mod Tidy
     #
@@ -234,6 +247,33 @@ You can pass multiple  `--hook:env:` arguments.
 
 The arguments can appear anywhere in the `args:` list.
 
+#### Invoking Hooks Via go tool
+You can invoke hooks via `go tool` to ensure that a specific version of a tool is used (requires Go 1.24+).
+
+This feature is enabled via support for several specially-formatted arguments:
+
+* `--hook:go-tool` : Invoke the hook via `go tool <hook> ...`
+* `--hook:go-tool-mod=FILE` : Pass `-modfile=FILE` to the `go tool` invocation.
+* `--hook:go-tool-arg:ARG` : Pass `ARG` to the `go tool` invocation (can be repeated).
+
+The hook script will detect these arguments and invoke the configured tool via `go tool`.
+
+**NOTE:** When using `go-tool-mod` or `go-tool-arg` flags, you do not need to also provide the base `go-tool` flag; their presence triggers the use of the `go tool` invocation implicitly.
+
+The arguments can appear anywhere in the `args:` list (before the optional `--`).
+
+**NOTE:** The plain versions of these arguments (without the `hook:` prefix) are also supported, but **ONLY** if they appear at the very beginning of the `args:` list:
+
+* `--go-tool`
+* `--go-tool-mod=FILE`
+* `--go-tool-arg:ARG`
+
+For more information:
+* [Go v1.24 Tools Announcement](https://tip.golang.org/doc/go1.24#tools)
+* [Go Tools Documentation](https://tip.golang.org/doc/modules/managing-dependencies#tools)
+
+See the [go-tool](#go-tool) hooks to invoke `go tools` directly with custom arguments.
+
 #### Passing Ignore Patterns To Hooks
 
 You can pass arguments to hooks to specify files / directories to ignore.
@@ -404,6 +444,7 @@ This can be useful, for example, for hooks that display warnings, but don't gene
 
  - Build Tools
    - [go-build](#go-build)
+   - [go-tool](#go-tool)
    - [go-mod-tidy](#go-mod-tidy)
  - Correctness Checkers
    - [go-test](#go-test)
@@ -443,6 +484,34 @@ Comes with Golang ( [golang.org](https://golang.org/) )
 ##### Help
  - https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies
  - `go help build`
+
+-----------
+### go-tool
+Runs the go tool command identified by the provided arguments.
+
+| Hook ID             | Description                                                              |
+|---------------------|--------------------------------------------------------------------------|
+| `go-tool`           | Run `'go tool [$ARGS] $FILE'` for each staged .go file                   |
+| `go-tool-mod`       | Run `'cd $(mod_root $FILE); go tool [$ARGS]'` for each staged .go file   |
+| `go-tool-repo`      | Run `'go tool [$ARGS]'` in the repo root folder                          |
+| `go-tool-repo-mod`  | Run `'cd $(mod_root); go tool [$ARGS]'` for each module in the repo      |
+
+Go ships with a number of builtin tools, and additional tools may be defined in the go.mod of the current module.
+
+##### See Also
+See [Invoking Hooks Via go tool](#invoking-hooks-via-go-tool) to invoke existing hooks via `go tool`.
+
+##### Install
+Comes with Golang ( [golang.org](https://golang.org/) )
+
+##### Useful Args
+```
+-modfile=file.mod : Use an alternate mod file (default: module's go.mod)
+```
+
+##### Help
+- https://go.dev/doc/go1.24#tools
+- `go help tool`
 
 ---------------
 ### go-mod-tidy

--- a/go-revive-mod.sh
+++ b/go-revive-mod.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 cmd=(revive)
 if [ -f "revive.toml" ]; then
-	cmd+=( "-config=revive.toml" )
+	cmd+=("-config=revive.toml")
 fi
 . "$(dirname "${0}")/lib/cmd-mod.bash"

--- a/go-revive-repo-mod.sh
+++ b/go-revive-repo-mod.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 cmd=(revive)
 if [ -f "revive.toml" ]; then
-	cmd+=( "-config=revive.toml" )
+	cmd+=("-config=revive.toml")
 fi
 . "$(dirname "${0}")/lib/cmd-repo-mod.bash"

--- a/go-tool-mod.sh
+++ b/go-tool-mod.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+cmd=(go tool)
+. "$(dirname "${0}")/lib/cmd-mod.bash"

--- a/go-tool-repo-mod.sh
+++ b/go-tool-repo-mod.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+cmd=(go tool)
+. "$(dirname "${0}")/lib/cmd-repo-mod.bash"

--- a/go-tool-repo.sh
+++ b/go-tool-repo.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+cmd=(go tool)
+. "$(dirname "${0}")/lib/cmd-repo.bash"

--- a/go-tool.sh
+++ b/go-tool.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+cmd=(go tool)
+. "$(dirname "${0}")/lib/cmd-files.bash"

--- a/lib/cmd-files.bash
+++ b/lib/cmd-files.bash
@@ -3,6 +3,9 @@
 # shellcheck source=./common.bash
 . "$(dirname "${0}")/lib/common.bash"
 
+# shellcheck source=./prepare-go-tool.bash
+. "$(dirname "${0}")/lib/prepare-go-tool.bash"
+
 prepare_file_hook_cmd "$@"
 
 error_code=0

--- a/lib/cmd-mod.bash
+++ b/lib/cmd-mod.bash
@@ -5,6 +5,9 @@
 # shellcheck source=./common.bash
 . "$(dirname "${0}")/lib/common.bash"
 
+# shellcheck source=./prepare-go-tool.bash
+. "$(dirname "${0}")/lib/prepare-go-tool.bash"
+
 prepare_file_hook_cmd "$@"
 
 if [ "${use_dot_dot_dot:-}" -eq 1 ]; then

--- a/lib/cmd-repo-mod.bash
+++ b/lib/cmd-repo-mod.bash
@@ -22,7 +22,7 @@ for file in $(find . -name go.mod | sort -u); do
 	if is_path_ignored_by_dir_pattern "${file_dir}" || is_path_ignored_by_file_pattern "${file}" || is_path_ignored_by_pattern "${file}"; then
 		continue
 	fi
-	pushd "${file_dir}" >/dev/null || exit 1
+	pushd "${file_dir}" > /dev/null || exit 1
 	if [ -n "${printf_module_announce}" ]; then
 		# shellcheck disable=SC2059 # Using variable as printf template
 		printf -- "${printf_module_announce}" "${file_dir#./}"
@@ -36,6 +36,6 @@ for file in $(find . -name go.mod | sort -u); do
 	elif ! /usr/bin/env "${ENV_VARS[@]}" "${cmd[@]}" "${OPTIONS[@]}"; then
 		error_code=1
 	fi
-	popd >/dev/null || exit 1
+	popd > /dev/null || exit 1
 done
 exit $error_code

--- a/lib/cmd-repo-mod.bash
+++ b/lib/cmd-repo-mod.bash
@@ -5,6 +5,9 @@
 # shellcheck source=./common.bash
 . "$(dirname "${0}")/lib/common.bash"
 
+# shellcheck source=./prepare-go-tool.bash
+. "$(dirname "${0}")/lib/prepare-go-tool.bash"
+
 prepare_repo_hook_cmd "$@"
 
 if [ "${use_dot_dot_dot:-}" -eq 1 ]; then

--- a/lib/cmd-repo.bash
+++ b/lib/cmd-repo.bash
@@ -3,6 +3,9 @@
 # shellcheck source=./common.bash
 . "$(dirname "${0}")/lib/common.bash"
 
+# shellcheck source=./prepare-go-tool.bash
+. "$(dirname "${0}")/lib/prepare-go-tool.bash"
+
 prepare_repo_hook_cmd "$@"
 
 # Add target after options

--- a/lib/cmd-repo.bash
+++ b/lib/cmd-repo.bash
@@ -1,4 +1,5 @@
 # shellcheck shell=bash
+: "${target:=}"
 
 # shellcheck source=./common.bash
 . "$(dirname "${0}")/lib/common.bash"
@@ -10,7 +11,7 @@ prepare_repo_hook_cmd "$@"
 
 # Add target after options
 #
-if [[ ${#target[@]} -gt 0 ]]; then
+if [[ "${#target[@]}" -gt 0 ]]; then
 	OPTIONS+=("${target[@]}")
 fi
 if [ "${error_on_output:-}" -eq 1 ]; then

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -1,5 +1,7 @@
 # shellcheck shell=bash
 
+: "${cmd:=}"
+: "${target:=}"
 : "${use_dot_dot_dot:=1}"
 : "${error_on_output:=0}"
 : "${ignore_pattern_array:=}"

--- a/lib/prepare-go-tool.bash
+++ b/lib/prepare-go-tool.bash
@@ -1,0 +1,91 @@
+# shellcheck shell=bash
+__USE_GO_TOOL=0
+__GO_TOOL_ARGS=()
+# Check for go-tool args
+# Naked args can *only* appear at the FRONT
+#
+while [ $# -gt 0 ] && [ "$1" != "--" ]; do
+	case "$1" in
+		--go-tool)
+			__USE_GO_TOOL=1
+			shift
+			;;
+		--go-tool-mod=*)
+			modfile="${1#--go-tool-mod=}"
+			if [ -n "${modfile}" ]; then
+				__USE_GO_TOOL=1
+				__GO_TOOL_ARGS+=("-modfile=${modfile}")
+			fi
+			shift
+			;;
+		--go-tool-arg:*)
+			arg="${1#--go-tool-arg:}"
+			if [ -n "${arg}" ]; then
+				__USE_GO_TOOL=1
+				__GO_TOOL_ARGS+=("${arg}")
+			fi
+			shift
+			;;
+		*) # preserve positional arguments
+			break
+			;;
+	esac
+done
+# '--hook:go-tool', '--hook:go-tool-mod', and '--hook:go-tool-arg' can appear anywhere before (the optional) '--'
+# Anything else (including '--' and after) gets saved and passed to next step
+# Positional order of saved arguments is preserved
+#
+__ARGS=()
+while [ $# -gt 0 ] && [ "$1" != "--" ]; do
+	case "$1" in
+		--hook:go-tool)
+			__USE_GO_TOOL=1
+			shift
+			;;
+		--hook:go-tool-mod=*)
+			modfile="${1#--go-tool-mod=}"
+			if [ -n "${modfile}" ]; then
+				__USE_GO_TOOL=1
+				__GO_TOOL_ARGS+=("-modfile=${modfile}")
+			fi
+			shift
+			;;
+		--hook:go-tool-arg:*)
+			arg="${1#--go-tool-arg:}"
+			if [ -n "${arg}" ]; then
+				__USE_GO_TOOL=1
+				__GO_TOOL_ARGS+=("${arg}")
+			fi
+			shift
+			;;
+		*) # preserve positional arguments
+			__ARGS+=("$1")
+			shift
+			;;
+	esac
+done
+set -- "${__ARGS[@]}" "${@}"
+unset __ARGS
+
+# Prepend go tool invocation to start of cmd array
+if [ "${__USE_GO_TOOL:-}" -eq 1 ]; then
+	new_cmd=("go" "tool")
+
+	# Go tool args
+	if [ "${#__GO_TOOL_ARGS[@]}" -gt 0 ]; then
+		new_cmd+=( "${__GO_TOOL_ARGS[@]}" )
+	fi
+
+	# Original cmd
+	if [ "${#cmd[@]}" -gt 0 ]; then
+		new_cmd+=( "${cmd[@]}" )
+	fi
+
+	# Set cmd to the new array
+	cmd=( "${new_cmd[@]}" )
+
+	unset new_cmd
+fi
+
+unset __USE_GO_TOOL
+unset __GO_TOOL_ARGS

--- a/lib/prepare-go-tool.bash
+++ b/lib/prepare-go-tool.bash
@@ -73,16 +73,16 @@ if [ "${__USE_GO_TOOL:-}" -eq 1 ]; then
 
 	# Go tool args
 	if [ "${#__GO_TOOL_ARGS[@]}" -gt 0 ]; then
-		new_cmd+=( "${__GO_TOOL_ARGS[@]}" )
+		new_cmd+=("${__GO_TOOL_ARGS[@]}")
 	fi
 
 	# Original cmd
 	if [ "${#cmd[@]}" -gt 0 ]; then
-		new_cmd+=( "${cmd[@]}" )
+		new_cmd+=("${cmd[@]}")
 	fi
 
 	# Set cmd to the new array
-	cmd=( "${new_cmd[@]}" )
+	cmd=("${new_cmd[@]}")
 
 	unset new_cmd
 fi

--- a/lib/prepare-my-cmd.bash
+++ b/lib/prepare-my-cmd.bash
@@ -12,7 +12,7 @@ fi
 # Anything else (including '--' and after) gets saved and passed to next step
 # Positional order of saved arguments is preserved
 #
-_ARGS=()
+__ARGS=()
 while [ $# -gt 0 ] && [ "$1" != "--" ]; do
 	case "$1" in
 		--hook:error-on-output)

--- a/sample-config.yaml
+++ b/sample-config.yaml
@@ -74,6 +74,12 @@ repos:
     #
     #           --hook:env:NAME=VALUE
     #
+    # NOTE: You can invoke hooks via 'go tool' using:
+    #
+    #           --hook:go-tool
+    #           --hook:go-tool-mod=MODFILE
+    #           --hook:go-tool-arg:ARG
+    #
     # Always Run:
     #   By default, hooks ONLY run when matching file types are staged.
     #   When configured to "always_run", a hook is executed as if EVERY matching
@@ -93,6 +99,13 @@ repos:
     -   id: go-build-pkg
     -   id: go-build-repo-mod
     -   id: go-build-repo-pkg
+    #
+    # Go Tool (Go 1.24+)
+    #
+    -   id: go-tool
+    -   id: go-tool-mod
+    -   id: go-tool-repo
+    -   id: go-tool-repo-mod
     #
     # Go Mod Tidy
     #


### PR DESCRIPTION
feat: Adds --hook:go-tool* arguments to enable hooks to be invokable via 'go tool'

feat: Adds go-hook* hooks to explicitly invoke go tool with custom arguments

docs: Updates README.md and sample-config.yaml for go-tool support

fix: Run pre-commit hooks and fix shellcheck/shfmt warnings

---

Fixes #46 

cc: @echarrod please give this branch a spin if you have time, thanks!
