### PR TITLE
Support both possible go-critic binary names

### DIFF
--- a/go-critic.sh
+++ b/go-critic.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
-cmd=(go-critic check)
+# Use legacy binary name if it exists; otherwise use the new binary name.
+if command -v gocritic >/dev/null 2>&1; then
+  binary_name="gocritic"
+else
+  binary_name="go-critic"
+fi
+
+cmd=("$binary_name" check)
 . "$(dirname "${0}")/lib/cmd-files.bash"


### PR DESCRIPTION
In https://github.com/TekWizely/pre-commit-golang/pull/45 the expected binary for [go-critic] was changed from `gocritic` to `go-critic` based on an effort to change binary names in the [go-critic] project (https://github.com/go-critic/go-critic/issues/1481 and https://github.com/go-critic/go-critic/pull/1482). However, even now the default binary is still `gocritic` if you install the project and not the `go-critic` command specifically. The same is true if you install using [brew] (per the [formula](https://github.com/Homebrew/homebrew-core/blob/960ba488f5fa8ccc62b579c7371397d67a0c9ae7/Formula/g/go-critic.rb))). Thus it makes sense to check for the legacy binary name (`gocritic`) and only if it is not found use the newer `go-critic` name.

I verified with `pre-commit try-repo` that this works as expected after installing [go-critic] with [brew].

[brew]: https://brew.sh/
[go-critic]: https://github.com/go-critic/go-critic