### PR TITLE
feat(go-critic): Fallback to 'gocritic' if 'go-critic' not found

### DIFF
--- a/go-critic.sh
+++ b/go-critic.sh
@@ -1,3 +1,12 @@
 #!/usr/bin/env bash
-cmd=(go-critic check)
+
+# Default to newer name
+# If not found, but old name found, us it
+# If neither found, leave newer for error reporting
+gocritic_bin='go-critic'
+if ! command -v go-critic &> /dev/null && command -v gocritic &> /dev/null; then
+	gocritic_bin='gocritic'
+fi
+
+cmd=("${gocritic_bin}" check)
 . "$(dirname "${0}")/lib/cmd-files.bash"

--- a/go-critic.sh
+++ b/go-critic.sh
@@ -1,3 +1,12 @@
 #!/usr/bin/env bash
-cmd=(go-critic check)
+
+# Default to newer name
+# If not found, but old name found, use it
+# If neither found, leave newer for error reporting
+gocritic_bin='go-critic'
+if ! command -v go-critic &> /dev/null && command -v gocritic &> /dev/null; then
+	gocritic_bin='gocritic'
+fi
+
+cmd=("${gocritic_bin}" check)
 . "$(dirname "${0}")/lib/cmd-files.bash"


### PR DESCRIPTION
Not all install-sources (brew, etc) have migrated to the new name (go-critic), so we provide a transparent fall-back to gocritic when it's the only version present.

If neither are present, we still use go-critic, so that it is used in the error reporting when verify_hook_cmd fails.

---

Replaces #50 

cc: @mcdonnnj - I wanted the checks to go in the other direction (prefer new, settle on old) and to have `go-critic` be in the error message if neither present.

Additionally, I've created https://github.com/go-critic/go-critic/issues/1525 on the go-critic project asking them to address the issue.