### PR TITLE
fix(go-tool): strip correct prefix for --hook:go-tool-mod / --hook:go-tool-arg

### DIFF
--- a/lib/prepare-go-tool.bash
+++ b/lib/prepare-go-tool.bash
@@ -43,7 +43,7 @@ while [ $# -gt 0 ] && [ "$1" != "--" ]; do
 			shift
 			;;
 		--hook:go-tool-mod=*)
-			modfile="${1#--go-tool-mod=}"
+			modfile="${1#--hook:go-tool-mod=}"
 			if [ -n "${modfile}" ]; then
 				__USE_GO_TOOL=1
 				__GO_TOOL_ARGS+=("-modfile=${modfile}")
@@ -51,7 +51,7 @@ while [ $# -gt 0 ] && [ "$1" != "--" ]; do
 			shift
 			;;
 		--hook:go-tool-arg:*)
-			arg="${1#--go-tool-arg:}"
+			arg="${1#--hook:go-tool-arg:}"
 			if [ -n "${arg}" ]; then
 				__USE_GO_TOOL=1
 				__GO_TOOL_ARGS+=("${arg}")


### PR DESCRIPTION
### Problem

In `lib/prepare-go-tool.bash`, the `--hook:`-prefixed branches strip the **non-prefixed** token, which never matches the actual argument:

```bash
--hook:go-tool-mod=*)
    modfile="${1#--go-tool-mod=}"   # ❌ arg starts with --hook: , so nothing is stripped
--hook:go-tool-arg:*)
    arg="${1#--go-tool-arg:}"       # ❌ same problem
```

Because `${1#pattern}` only strips when `pattern` matches from the start, the raw `--hook:...` string is left untouched and passed straight to `go tool`:

```
flag provided but not defined: -hook:go-tool-arg:nm
usage: go tool [-n] command [args...]
```

The front-only forms (`--go-tool-mod=` / `--go-tool-arg:`, lines 14/22) are already correct; only the `--hook:`-prefixed branches are affected.

### Fix

Strip the matching `--hook:`-prefixed token so the value is extracted correctly:

```bash
modfile="${1#--hook:go-tool-mod=}"
arg="${1#--hook:go-tool-arg:}"
```

`shellcheck -x` clean.

### Verification

Before: `--hook:go-tool-arg:<tool>` fails with *flag provided but not defined*.
After: the value is parsed and `go tool <tool> ...` is invoked correctly; hook passes.

> Note: this requires #53 (executable bit) to be applied as well, otherwise the script never runs far enough to reach the parser. Together the two fixes make the `go-tool*` hooks work end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNpNoLxAejLE3NE74PbmiC